### PR TITLE
feat: Allow to use a local http Cozy

### DIFF
--- a/src/Core/Services/CozyClientService.cs
+++ b/src/Core/Services/CozyClientService.cs
@@ -176,7 +176,9 @@ namespace Bit.Core.Services
         public async Task ConfigureEnvironmentFromCozyURLAsync(string cozyURL)
         {
             var environmentData = new EnvironmentUrlData();
-            environmentData.Base = string.Concat("https://", cozyURL, "/bitwarden");
+            var scheme = cozyURL.StartsWith("http://") ? "" : "https://";
+            var baseURL = string.Concat(scheme, cozyURL, "/bitwarden");
+            environmentData.Base = baseURL;
             await _environmentService.SetUrlsAsync(environmentData);
         }
     }

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -116,5 +116,17 @@
 	<string>Use Face ID to unlock your vault.</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Use Yubikeys for two-factor authentication.</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>cozy.tools</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+
 </dict>
 </plist>


### PR DESCRIPTION
Since the https:// was added automatically, it was not possible
to use a local stack. We now detect this case and do not add
https:// if the URL starts with http.

Since http is disallowed by default, by the application policies,
a setting must be added in the Info.plist. This setting is added
to the file as a comment for convenience.