### PR TITLE
fix: Do not crash when uri field is null or whitespace

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:versionName="2.3.8" package="io.cozy.pass" android:versionCode="2003008">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:versionName="2.3.9" package="io.cozy.pass" android:versionCode="2003009">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.NFC" />

--- a/src/Core/Models/Domain/Domain.cs
+++ b/src/Core/Models/Domain/Domain.cs
@@ -23,8 +23,13 @@ namespace Bit.Core.Models.Domain
                 }
                 else
                 {
-                    domainPropInfo.SetValue(domain,
-                        dataObjProp != null ? new CipherString(dataObjProp as string) : null, null);
+                    domainPropInfo.SetValue(
+                        domain,
+                        dataObjProp != null && !string.IsNullOrWhiteSpace(dataObjProp as string)
+                            ? new CipherString(dataObjProp as string)
+                            : null,
+                        null
+                    );
                 }
             }
         }

--- a/src/iOS.Autofill/Info.plist
+++ b/src/iOS.Autofill/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.autofill</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.8</string>
+	<string>2.3.9</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -87,6 +87,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>71</string>
+	<string>72</string>
 </dict>
 </plist>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.find-login-action-extension</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.8</string>
+	<string>2.3.9</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -104,6 +104,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>71</string>
+	<string>72</string>
 </dict>
 </plist>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.8</string>
+	<string>2.3.9</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleURLTypes</key>
@@ -126,6 +126,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>71</string>
+	<string>72</string>
 </dict>
 </plist>


### PR DESCRIPTION
In the addon, it is possible to create empty URI field. These empty fields
make the app crash, since we try to decipher them down the line.