### PR TITLE
fix: add missing nuget packages for Newtonsoft.Json

### DIFF
--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -251,5 +251,10 @@
   <ItemGroup>
     <BundleResource Include="Resources\logo_white%403x.png" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
 </Project>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -228,5 +228,10 @@
     <BundleResource Include="Resources\logo_white%402x.png" />
     <BundleResource Include="Resources\logo_white%403x.png" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Implicit `Newtonsoft.json` references were handled by `HockeySDK` but broke after `HockeySDK` removal on commit 1064354842c189e9026181add180f39f83e65c58.

This bug is not visible on existing dev environments as the old nuget package may still be referenced in `bin/` and `obj/` folders.
But it appears after trying to compile a fresh project. It can also be reproduced by deleting all `bin/` and `obj/` folders from the solution.

Note that `Newtonsoft.json` package has been added to `iOS.Autofill` and `iOS.Extension` projects although it is only used by the `Core` project.
This is because `Core` is a "standard/PCL" library that is independent of the platform. So every project that uses `Core` needs to include a platform specific version of `Newtonsoft.json`.