### PR TITLE
fix: change password hints to prevent ambiguity on which password to use

### DIFF
--- a/src/App/Resources/AppResources.en-GB.resx
+++ b/src/App/Resources/AppResources.en-GB.resx
@@ -168,7 +168,7 @@
     <comment>Label for Cozy URL input</comment>
   </data>
   <data name="CozyPassword" xml:space="preserve">
-    <value>Cozy password</value>
+    <value>Password</value>
     <comment>Label for Cozy password</comment>
   </data>
   <data name="Credits" xml:space="preserve">

--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -172,7 +172,7 @@
     <comment>Placeholder for Cozy URL input</comment>
   </data>
   <data name="CozyPassword" xml:space="preserve">
-    <value>Mot de passe du Cozy</value>
+    <value>Mot de passe</value>
     <comment>Label for Cozy password</comment>
   </data>
   <data name="Credits" xml:space="preserve">

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -172,7 +172,7 @@
     <comment>Placeholder for Cozy URL input</comment>
   </data>
   <data name="CozyPassword" xml:space="preserve">
-    <value>Your Cozy password</value>
+    <value>Password</value>
     <comment>Label for Cozy password</comment>
   </data>
   <data name="Credits" xml:space="preserve">


### PR DESCRIPTION
Some users have to use their organization password and not their "cozy" password. The previous wording would introduce ambiguity (cozy password vs organization password).