### PR TITLE
chore: bump to 2.4.1

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:versionName="2.4.0" package="io.cozy.pass" android:versionCode="2004003">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:versionName="2.4.1" package="io.cozy.pass" android:versionCode="2004100">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.NFC" />

--- a/src/iOS.Autofill/Info.plist
+++ b/src/iOS.Autofill/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.autofill</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -87,6 +87,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>74</string>
+	<string>2004101</string>
 </dict>
 </plist>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.find-login-action-extension</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -104,6 +104,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>74</string>
+	<string>2004101</string>
 </dict>
 </plist>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleURLTypes</key>
@@ -126,6 +126,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>74</string>
+	<string>2004101</string>
 </dict>
 </plist>


### PR DESCRIPTION
Updated versions before publishing on stores.