### PR TITLE
Fix/register button

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -406,7 +406,7 @@
 
   <ItemGroup>
     <Reference Include="Xamarin.iOS">
-      <HintPath>..\..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\13.14.1.39\lib\mono\Xamarin.iOS\Xamarin.iOS.dll</HintPath>
+      <HintPath>\Library\Frameworks\Xamarin.iOS.framework\Versions\Current\lib\mono\Xamarin.iOS\Xamarin.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -6,12 +6,9 @@ using System.Threading.Tasks;
 using Xamarin.Forms;
 using Bit.App.Resources;
 
-
-#if __IOS__
 using SafariServices;
 using Foundation;
 using UIKit;
-#endif
 
 namespace Bit.App.Pages
 {
@@ -81,7 +78,6 @@ namespace Bit.App.Pages
 
         
         private void OpenRegistrationPageIOS(string url) {
-            #if __IOS__
             var window = UIApplication.SharedApplication.KeyWindow;
             var vc = window.RootViewController;
             var sfvc = new SFSafariViewController(new NSUrl(url), true);
@@ -92,7 +88,6 @@ namespace Bit.App.Pages
             // closed there since messages on the broadcast service are not
             // received by the HomePage while the SafariViewController is
             // presented
-            #endif
         }
 
 

--- a/src/iOS.Autofill/Info.plist
+++ b/src/iOS.Autofill/Info.plist
@@ -87,6 +87,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>2004101</string>
+	<string>2004102</string>
 </dict>
 </plist>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -104,6 +104,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>2004101</string>
+	<string>2004102</string>
 </dict>
 </plist>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -126,6 +126,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>2004101</string>
+	<string>2004102</string>
 </dict>
 </plist>


### PR DESCRIPTION
IOS `Create Account` button was not working due to __IOS__ preprocessor directives not being handled by Visual Studio with the current project configuration.

Also iOS was not able to compile without __IOS__ preprocessor directives due to missing dependence on Xamarin.iOS.dll. This dependence has been added back using the generic path so it can be version agnostic and may be future proof.