### PR TITLE
feat: hide ciphers with no organization's key

### DIFF
--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -244,7 +244,14 @@ namespace Bit.Core.Services
                         decCiphers.Add(c);
                     }
                     var tasks = new List<Task>();
-                    var ciphers = await GetAllAsync();
+
+                    var orgKeys = await _cryptoService.GetOrgKeysAsync();
+                    var orgIds = orgKeys.Keys;
+
+                    var ciphers = (await GetAllAsync())
+                        .Where(cipher => cipher.OrganizationId == null || orgIds.Contains(cipher.OrganizationId))
+                        .ToList();
+
                     foreach(var cipher in ciphers)
                     {
                         tasks.Add(decryptAndAddCipherAsync(cipher));

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -85,7 +85,10 @@ namespace Bit.Core.Services
 
         public async Task SetOrgKeysAsync(IEnumerable<ProfileOrganizationResponse> orgs)
         {
-            var orgKeys = orgs.ToDictionary(org => org.Id, org => org.Key);
+            var orgKeys = orgs
+                .Where(org => org.Key != "")
+                .ToDictionary(org => org.Id, org => org.Key);
+
             _orgKeys = null;
             await _storageService.SaveAsync(Keys_EncOrgKeys, orgKeys);
         }
@@ -247,6 +250,8 @@ namespace Bit.Core.Services
                     var setKey = false;
                     foreach(var org in encOrgKeys)
                     {
+                        if (string.IsNullOrWhiteSpace(org.Value)) continue;
+
                         var decValue = await RsaDecryptAsync(org.Value);
                         orgKeys.Add(org.Key, new SymmetricCryptoKey(decValue));
                         setKey = true;


### PR DESCRIPTION
When an organization is shared with Bob but Alice did not confirm
Bob's fingerprint yet, then Bob receive the organization data with no
`key` attached

Ciphers from those organizations are displayed with an
`encryption error` title

This commit hide those ciphers from the cipher view, so Bob cannot
see them until Alice confirms him

Mirrored from cozy/cozy-pass-web@7d4d6226d57b0ef8a77e1f3b27d412aaf94b63d1