### PR TITLE
fix: correctly handle settings/import link generation

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -167,9 +167,9 @@ namespace Bit.App.Pages
             _deviceActionService.RateApp();
         }
 
-        public void Import()
+        public async void Import()
         {
-            var passwordsURL = _cozyClientService.GetURLForApp("passwords", fragment: "/installation/import");
+            var passwordsURL = await _cozyClientService.GetURLForApp("passwords", fragment: "/vault?action=import");
             _platformUtilsService.LaunchUri(passwordsURL);
         }
 
@@ -199,7 +199,7 @@ namespace Bit.App.Pages
                 AppResources.TwoStepLogin, AppResources.Yes, AppResources.Cancel);
             if (confirmed)
             {
-                var twoFAURL = _cozyClientService.GetURLForApp("settings", fragment: "/profile");
+                var twoFAURL = await _cozyClientService.GetURLForApp("settings", fragment: "/profile");
                 _platformUtilsService.LaunchUri(twoFAURL);
             }
         }

--- a/src/Core/Abstractions/ICozyClientService.cs
+++ b/src/Core/Abstractions/ICozyClientService.cs
@@ -13,7 +13,7 @@ namespace Bit.Core.Abstractions
         Task<LogoutResponse> LogoutAsync();
         string GetEmailFromCozyURL(string cozyURL);
         Task ConfigureEnvironmentFromCozyURLAsync(string cozyURL);
-        string GetURLForApp(string appname, string fragment);
+        Task<string> GetURLForApp(string appname, string fragment);
         string GetRegistrationURL(string lang);
         bool CheckStateAndSecretInOnboardingCallbackURL();
         Task UpdateSynchronizedAtAsync();

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1" />
+    <PackageReference Include="Flurl" Version="3.0.2" />
     <PackageReference Include="LiteDB" Version="5.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />

--- a/src/Core/Utilities/UrlHelper.cs
+++ b/src/Core/Utilities/UrlHelper.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Flurl;
+
+namespace Bit.Core.Utilities
+{
+    public static class UrlHelper
+    {
+        // Code taken from CozyClient.EnsureFirstSlash()
+        private static string EnsureFirstSlash(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return "/";
+            }
+            else
+            {
+                return path.StartsWith("/") ? path : "/" + path;
+            }
+        }
+
+        /// <summary>
+        /// Construct a link to a web app
+        /// 
+        /// This function does not get its cozy url from a CozyClient instance so it can
+        /// be used to build urls that point to other Cozies than the user's own Cozy.
+        /// This is useful when pointing to the Cozy of the owner of a shared note for
+        /// example.
+        /// 
+        /// Code taken from CozyClient.generateWebLink()
+        /// </summary>
+        /// <param name="cozyUrl">Base URL of the cozy, eg. cozy.tools or test.mycozy.cloud</param>
+        /// <param name="searchParams">Dictionary of search parameters as {key, value}, eg. {'username', 'bob'}</param>
+        /// <param name="pathname">Path to a specific part of the app, eg. /public</param>
+        /// <param name="hash">Path inside the app, eg. /files/test.jpg</param>
+        /// <param name="slug">Slug of the app</param>
+        /// <param name="subDomainType">Whether the cozy is using flat or nested subdomains. Defaults to flat.</param>
+        /// <returns>Generated URL</returns>
+        public static string GenerateWebLink(
+            string cozyUrl,
+            Dictionary<string, string> searchParams,
+            string pathname,
+            string hash,
+            string slug,
+            string subDomainType
+        )
+        {
+            if (searchParams == null)
+            {
+                searchParams = new Dictionary<string, string>();
+            }
+
+            var url = new Url(cozyUrl);
+
+            if (subDomainType == "nested")
+            {
+                url.Host = $"{slug}.{url.Host}";
+            }
+            else
+            {
+                var hostParts = url.Host
+                        .Split('.')
+                        .Select((x, i) => i == 0 ? x + '-' + slug : x);
+
+                url.Host = string.Join(".", hostParts);
+            }
+
+            url.Path = EnsureFirstSlash(pathname);
+            url.Fragment = EnsureFirstSlash(hash);
+
+            foreach (var entry in searchParams)
+            {
+                url.QueryParams.Add(entry.Key, entry.Value);
+            }
+
+            return url.ToString();
+        }
+    }
+}

--- a/test/Core.Test/Utilities/UrlHelperTests.cs
+++ b/test/Core.Test/Utilities/UrlHelperTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using Bit.Core.Utilities;
+using Xunit;
+
+namespace Bit.Core.Test.Utilities
+{
+    public class UrlHelperTests
+    {
+        [Fact]
+        public void GenerateWebLink_GeneratesTheRightLinkToAFlatCozy()
+        {
+            var sharecode = "sharingIsCaring";
+            var username = "alice";
+
+            var webLink = UrlHelper.GenerateWebLink(
+                cozyUrl: "http://alice.cozy.tools",
+                searchParams: new Dictionary<string, string>()
+                {
+                    { "sharecode", sharecode },
+                    { "username", username },
+                },
+                pathname: "public",
+                hash: "/n/4",
+                slug: "notes",
+                subDomainType: "flat"
+            );
+
+            Assert.Equal($"http://alice-notes.cozy.tools/public?sharecode={sharecode}&username={username}#/n/4", webLink);
+        }
+
+        [Fact]
+        public void GenerateWebLink_GeneratesTheRightLinkToANestedCozy()
+        {
+            var webLink = UrlHelper.GenerateWebLink(
+                cozyUrl: "https://alice.cozy.tools",
+                searchParams: null,
+                pathname: "/public/",
+                hash: "files/432432",
+                slug: "drive",
+                subDomainType: "nested"
+            );
+
+            Assert.Equal("https://drive.alice.cozy.tools/public/#/files/432432", webLink);
+        }
+
+        [Fact]
+        public void GenerateWebLink_CorrectlySetsSlashBeforeFragmentIfNoPath()
+        {
+            // Even if "/" is not mandatory in URL before the Hash, we want to be iso with CozyClient's behavior
+            var webLink = UrlHelper.GenerateWebLink(
+                cozyUrl: "https://alice.cozy.tools",
+                searchParams: null,
+                pathname: "",
+                hash: "/vault?action=import",
+                slug: "passwords",
+                subDomainType: "flat"
+            );
+
+            Assert.Equal("https://alice-passwords.cozy.tools/#/vault?action=import", webLink);
+        }
+    }
+}


### PR DESCRIPTION
Like for the extension, the mobile app was not handling subdomain type correctly. Also it was still using the old route parameters (`/installation/import` vs `/vault?action=import`)

This PR fixes those problems