### PR TITLE
Fix/disable attachments notes

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage 
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -575,6 +575,9 @@
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" />
             </StackLayout>
+            <!-- Cozy customization -->
+            <!-- Notes are disabled to avoid confusion with Cozy Notes -->
+            <!--
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n Notes, Header=True}"
@@ -589,6 +592,7 @@
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowNotesSeparator}" />
             </StackLayout>
+            -->
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n CustomFields, Header=True}"

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -59,7 +59,11 @@ namespace Bit.App.Pages
             SetActivityIndicator();
             if (_vm.EditMode && !_vm.CloneMode && Device.RuntimePlatform == Device.Android)
             {
+                // Cozy customization, disable attachment
+                // Disable attachment as they are not implemented in Cozy Stack
+                /*
                 ToolbarItems.Add(_attachmentsItem);
+                //*/
                 ToolbarItems.Add(_deleteItem);
             }
             if (Device.RuntimePlatform == Device.iOS)

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -34,7 +34,11 @@ namespace Bit.App.Pages
             else
             {
                 _mainLayout.Padding = new Thickness(0, 0, 0, 75);
+                // Cozy customization, disable attachment
+                // Disable attachment as they are not implemented in Cozy Stack
+                /*
                 ToolbarItems.Add(_attachmentsItem);
+                //*/
                 ToolbarItems.Add(_deleteItem);
             }
         }


### PR DESCRIPTION
Notes are disabled to avoid confusion with Cozy Notes

Attachments are disabled as they are not implemented on Cozy Stack
