### PR TITLE
fix: correctly handle ciphers login ellipsis

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <controls:ExtendedGrid xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Controls.CipherViewCell"
@@ -56,7 +56,6 @@
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />


### PR DESCRIPTION
On `grouping` view ciphers subtitles are truncated if too long

A supernumerary column declaration was breaking the grid and ciphers
subtitles were truncated if longer than the cipher's name, even if
there was enough place to display them completly

Now ciphers subtitles take all available space and are truncated only
if larger than the screen

This reverts part of d3d7e0b8988ac7707bdd32eac2aa879ff7feb924

____________

Before:
![image](https://user-images.githubusercontent.com/1884255/143552909-1c8f7630-c53b-49bc-bf4f-4a3835e70e75.png)


After:
![image](https://user-images.githubusercontent.com/1884255/143554308-37ba0a87-daba-4c92-90fb-96a8d554a2a4.png)
