### PR TITLE
fix: disable attachments from iOS

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -1,4 +1,4 @@
-using Bit.App.Abstractions;
+﻿using Bit.App.Abstractions;
 using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.App.Utilities;
@@ -301,7 +301,13 @@ namespace Bit.App.Pages
             {
                 return;
             }
+            // Cozy customization, disable attachment
+            // Disable attachment as they are not implemented in Cozy Stack
+            /*
             var options = new List<string> { AppResources.Attachments };
+            /*/
+            var options = new List<string> { };
+            //*/
             if (_vm.EditMode)
             {
                 // Cozy customization, replace collection action by move action

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
@@ -243,7 +243,13 @@ namespace Bit.App.Pages
                 return;
             }
 
+            // Cozy customization, disable attachment
+            // Disable attachment as they are not implemented in Cozy Stack
+            /*
             var options = new List<string> {AppResources.Attachments};
+            /*/
+            var options = new List<string> { };
+            //*/
             if (_vm.Cipher.OrganizationId == null)
             {
                 options.Add(AppResources.Clone);


### PR DESCRIPTION
This PR removes `Attachments` menu from iOS cipher view and edit pages

It was removed from Android earlier but I didn't notice that iOS version implements it in a different way

___
Attachments are not implemented on Cozy Stack

Related commit: 15ceddf64d4a29dac2a158ded56c8d5e65819e7d