### PR TITLE
fix: translate `move` confirm button when moving a cipher to a folder

### DIFF
--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -340,7 +340,7 @@
     <comment>Button text for a save operation (verb).</comment>
   </data>
   <data name="Move" xml:space="preserve">
-    <value>Move</value>
+    <value>Valider</value>
   </data>
   <data name="Saving" xml:space="preserve">
     <value>Enregistrement...</value>


### PR DESCRIPTION
We chose to translate `move` to `valider` as the button is here to
confirm the action

`déplacer` is redundant with the page title `Déplacer dans un dossier`
and also is longer than `valider`. So it seems to be a better choice
for a clean interface

![image](https://user-images.githubusercontent.com/1884255/144066564-823c16c0-9f1d-4dde-b1da-e3af2561f012.png)
