### PR TITLE
Fix/set correct service name

### DIFF
--- a/src/Android/Resources/values/strings.xml
+++ b/src/Android/Resources/values/strings.xml
@@ -5,7 +5,7 @@
   </string>
   <string name="AutoFillServiceDescription">
     It can be difficult and insecure for users to switch between apps to copy/paste username and password information
-    from their Cozy Pass vault.\n\nUsing this accessibility service allows Bitwarden to detect and read input fields on
+    from their Cozy Pass vault.\n\nUsing this accessibility service allows Cozy Pass to detect and read input fields on
     your device\'s screen. Whenever Cozy Pass detects a password field on the screen a notification will appear that allows
     you to quickly access your Cozy Pass vault and automatically fill (auto-fill) the correct login information into the
     necessary fields.

--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -140,7 +140,7 @@
     <comment>Navigate back to the previous screen.</comment>
   </data>
   <data name="Bitwarden" xml:space="preserve">
-    <value>Bitwarden</value>
+    <value>Cozy Pass</value>
     <comment>App name. Shouldn't ever change.</comment>
   </data>
   <data name="Cancel" xml:space="preserve">

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -140,7 +140,7 @@
     <comment>Navigate back to the previous screen.</comment>
   </data>
   <data name="Bitwarden" xml:space="preserve">
-    <value>Bitwarden</value>
+    <value>Cozy Pass</value>
     <comment>App name. Shouldn't ever change.</comment>
   </data>
   <data name="Cancel" xml:space="preserve">


### PR DESCRIPTION
Some translations were still refering to Bitwarden instead of Cozy Pass

Those were visible when using fingerprint scan (which is not available on emulators).