### PR TITLE
Feat/display error msg in login form

### DIFF
--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -89,6 +89,8 @@
                 <Label Text="{Binding PageTitle}" HorizontalTextAlignment="Center" Margin="0,0,0,0" FontSize="Title"/>
                 <Label Text="{Binding LoggedInAsText}" HorizontalTextAlignment="Center" Margin="0,0,0,20" FontSize="Small" Opacity="0.64"/>
 
+                <Label Text="{Binding ErrorMsg}" HorizontalTextAlignment="Center" Margin="0,0,0,20" FontSize="Medium" StyleClass="text-danger" />
+
                 <Grid StyleClass="box-row" IsVisible="{Binding PinLock}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -44,6 +44,11 @@ namespace Bit.App.Pages
         private string _avatarUrl;
         //*/
 
+        // Cozy customization, display error message on form
+        //*
+        private string _errorMsg;
+        //*/
+
         public LockPageViewModel()
         {
             _apiService = ServiceContainer.Resolve<IApiService>("apiService");
@@ -122,6 +127,15 @@ namespace Bit.App.Pages
         {
             get => _avatarUrl;
             set => SetProperty(ref _avatarUrl, value);
+        }
+        //*/
+
+        // Cozy customization, display error message on form
+        //*
+        public string ErrorMsg
+        {
+            get => _errorMsg;
+            set => SetProperty(ref _errorMsg, value);
         }
         //*/
 
@@ -210,18 +224,33 @@ namespace Bit.App.Pages
 
         public async Task SubmitAsync()
         {
+            // Cozy customization, display error message on form
+            //*
+            ErrorMsg = "";
+            //*/
+
             if (PinLock && string.IsNullOrWhiteSpace(Pin))
             {
+                // Cozy customization, display error message on form
+                /*
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
                     string.Format(AppResources.ValidationFieldRequired, AppResources.PIN),
                     AppResources.Ok);
+                /*/
+                ErrorMsg = string.Format(AppResources.ValidationFieldRequired, AppResources.PIN);
+                //*/
                 return;
             }
             if (!PinLock && string.IsNullOrWhiteSpace(MasterPassword))
             {
+                // Cozy customization, display error message on form
+                /*
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
                     string.Format(AppResources.ValidationFieldRequired, AppResources.MasterPassword),
                     AppResources.Ok);
+                /*/
+                ErrorMsg = string.Format(AppResources.ValidationFieldRequired, AppResources.MasterPassword);
+                //*/
                 return;
             }
 
@@ -272,8 +301,13 @@ namespace Bit.App.Pages
                         _messagingService.Send("logout");
                         return;
                     }
+                    // Cozy customization, display error message on form
+                    /*
                     await _platformUtilsService.ShowDialogAsync(AppResources.InvalidPIN,
                         AppResources.AnErrorHasOccurred);
+                    /*/
+                    ErrorMsg = AppResources.InvalidPIN;
+                    //*/
                 }
             }
             else
@@ -334,8 +368,13 @@ namespace Bit.App.Pages
                         _messagingService.Send("logout");
                         return;
                     }
+                    // Cozy customization, display error message on form
+                    /*
                     await _platformUtilsService.ShowDialogAsync(AppResources.InvalidMasterPassword,
                         AppResources.AnErrorHasOccurred);
+                    /*/
+                    ErrorMsg = AppResources.InvalidMasterPassword;
+                    //*/
                 }
             }
         }

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -44,6 +44,7 @@
         <StackLayout Spacing="20">
             <StackLayout StyleClass="box">
                 <Label Text="{u:I18n CozyLoginTitle}" HorizontalTextAlignment="Center" Margin="0,0,0,20" FontSize="Title"/>
+                <Label Text="{Binding ErrorMsg}" HorizontalTextAlignment="Center" Margin="0,0,0,20" FontSize="Medium" StyleClass="text-danger" />
                 <StackLayout StyleClass="box-row">
                     <Label
                         Text="{u:I18n CozyURL}"

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -32,6 +32,11 @@ namespace Bit.App.Pages
         private string _email;
         private string _masterPassword;
 
+        // Cozy customization, display error message on form
+        //*
+        private string _errorMsg;
+        //*/
+
         public LoginPageViewModel()
         {
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
@@ -71,6 +76,15 @@ namespace Bit.App.Pages
             set => SetProperty(ref _masterPassword, value);
         }
 
+        // Cozy customization, display error message on form
+        //*
+        public string ErrorMsg
+        {
+            get => _errorMsg;
+            set => SetProperty(ref _errorMsg, value);
+        }
+        //*/
+
         public Command LogInCommand { get; }
         public Command TogglePasswordCommand { get; }
         public string ShowPasswordIcon => ShowPassword ? "" : "";
@@ -97,17 +111,32 @@ namespace Bit.App.Pages
 
         public async Task LogInAsync(bool showLoading = true)
         {
+            // Cozy customization, display error message on form
+            //*
+            ErrorMsg = "";
+            //*/
+
             if (Xamarin.Essentials.Connectivity.NetworkAccess == Xamarin.Essentials.NetworkAccess.None)
             {
+                // Cozy customization, display error message on form
+                /*
                 await _platformUtilsService.ShowDialogAsync(AppResources.InternetConnectionRequiredMessage,
                     AppResources.InternetConnectionRequiredTitle, AppResources.Ok);
+                /*/
+                ErrorMsg = AppResources.InternetConnectionRequiredMessage;
+                //*/
                 return;
             }
             if (string.IsNullOrWhiteSpace(Email))
             {
+                // Cozy customization, display error message on form
+                /*
                 await _platformUtilsService.ShowDialogAsync(
                     string.Format(AppResources.ValidationFieldRequired, AppResources.EmailAddress),
                     AppResources.AnErrorHasOccurred, AppResources.Ok);
+                /*/
+                ErrorMsg = string.Format(AppResources.ValidationFieldRequired, AppResources.EmailAddress);
+                //*/
                 return;
             }
 
@@ -125,9 +154,14 @@ namespace Bit.App.Pages
 
             if (string.IsNullOrWhiteSpace(MasterPassword))
             {
+                // Cozy customization, display error message on form
+                /*
                 await _platformUtilsService.ShowDialogAsync(
                     string.Format(AppResources.ValidationFieldRequired, AppResources.MasterPassword),
                     AppResources.AnErrorHasOccurred, AppResources.Ok);
+                /*/
+                ErrorMsg = string.Format(AppResources.ValidationFieldRequired, AppResources.MasterPassword);
+                //*/
                 return;
             }
 
@@ -194,7 +228,8 @@ namespace Bit.App.Pages
             {
                 await _deviceActionService.HideLoadingAsync();
                 var translatedErrorMessage = AppResources.ResourceManager.GetString(e.GetType().Name, AppResources.Culture);
-                await _platformUtilsService.ShowDialogAsync(translatedErrorMessage, AppResources.AnErrorHasOccurred, AppResources.Ok);
+                // await _platformUtilsService.ShowDialogAsync(translatedErrorMessage, AppResources.AnErrorHasOccurred, AppResources.Ok);
+                ErrorMsg = translatedErrorMessage;
             }
             //*/
             catch (ApiException e)
@@ -214,7 +249,8 @@ namespace Bit.App.Pages
                     if (e.Error.StatusCode == HttpStatusCode.Unauthorized)
                     {
                         var translatedErrorMessage = AppResources.ResourceManager.GetString("CozyInvalidLoginException", AppResources.Culture);
-                        await _platformUtilsService.ShowDialogAsync(translatedErrorMessage, AppResources.AnErrorHasOccurred, AppResources.Ok);
+                        // await _platformUtilsService.ShowDialogAsync(translatedErrorMessage, AppResources.AnErrorHasOccurred, AppResources.Ok);
+                        ErrorMsg = translatedErrorMessage;
                     }
                     else
                     {


### PR DESCRIPTION
Error messages are now displayed in login and unlock forms instead of in a toast

Unexpected error messages (like 500 errors) are still displayed in a
toast as we do not control message size

![image](https://user-images.githubusercontent.com/1884255/144822906-173914ef-e0f3-4501-b6c2-d12f051b1326.png)
