### PR TITLE
feat: set inverted theme for iOS autofill `unlock` form

### DIFF
--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -103,6 +103,17 @@ namespace Bit.iOS.Core.Controllers
 
             base.ViewDidLoad();
 
+            // Cozy customization, change unlock form style to match inverted theme
+            //*
+            MasterPasswordCell.TextField.BackgroundColor = ThemeHelpers.PrimaryColor;
+            MasterPasswordCell.TextField.TextColor = ThemeHelpers.BackgroundColor;
+            MasterPasswordCell.TextField.TintColor = ThemeHelpers.BackgroundColor;
+            MasterPasswordCell.Label.TextColor = ThemeHelpers.BackgroundColor;
+            MasterPasswordCell.BackgroundColor = ThemeHelpers.PrimaryColor;
+            TableView.BackgroundColor = ThemeHelpers.PrimaryColor;
+            TableView.SeparatorColor = ThemeHelpers.BackgroundColor;
+            //*/
+
             if (_biometricLock)
             {
                 if (!_biometricIntegrityValid)


### PR DESCRIPTION
Contrary to Android version, iOS uses a native project to display
autofill pages

Unlock form from iOS autofill is now using Inverted theme color scheme

⚠️ I didn't find how to change the clear button's color (current version is black). Any suggestion would be appreciated.

![image](https://user-images.githubusercontent.com/1884255/144898571-b9ef6b6d-d6a1-4ada-91d5-047ec03704b2.png)
