### PR TITLE
feat: edit `move to folder` description

### DIFF
--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -1461,7 +1461,7 @@
     <value>Aucun dossier à afficher.</value>
   </data>
   <data name="MoveToOrgDesc" xml:space="preserve">
-    <value>Choisissez un dossier avec lequel vous voulez partager cet élément. Le partage transfère la propriété de l'élément au dossier. Vous ne serez plus le propriétaire direct de cet élément après le partage.</value>
+    <value>Choisissez un dossier dans lequel vous souhaitez ranger cet élément.&#10;&#10;Astuce : en sélectionnant un dossier partagé, vous pourrez ainsi transmettre cet élément de manière sécurisé à d'autres utilisateurs qui possèdent un Cozy.</value>
   </data>
   <data name="NumberOfWords" xml:space="preserve">
     <value>Nombre de mots</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1461,7 +1461,7 @@
     <value>No folder to list.</value>
   </data>
   <data name="MoveToOrgDesc" xml:space="preserve">
-    <value>Choose a folder that you wish to share this item with. Sharing transfers ownership of the item to the folder. You will no longer be the direct owner of this item once it has been shared.</value>
+    <value>Choose a folder to store this item.&#10;&#10;Tips: after selecting a shared folder, you will be able to securely share this element with other Cozy users.</value>
   </data>
   <data name="NumberOfWords" xml:space="preserve">
     <value>Number of Words</value>


### PR DESCRIPTION
This PR change the description of `move to folder` popup in order to fit Cozy's spec

### French:
![image](https://user-images.githubusercontent.com/1884255/144899305-dd8dc93b-b47a-4a0f-9734-2459a1be2369.png)

### English:
![image](https://user-images.githubusercontent.com/1884255/144899351-288aaff1-fdf6-4e6b-94fa-091011dbc22e.png)
