### PR TITLE
feat: user a different icon for ciphers that are in "Cozy Connectors"

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -82,7 +82,7 @@
             Margin="4, 4, 0, 0"
             HorizontalOptions="Start"
             IsVisible="{Binding CozyShared, Mode=OneWay}"
-            Source="shared_with_cozy_icon.png" />
+            Source="{Binding CozySharedImage}" />
         <controls:FaLabel
             Grid.Column="2"
             Grid.Row="0"

--- a/src/App/Controls/CipherViewCell/CipherViewCellViewModel.cs
+++ b/src/App/Controls/CipherViewCell/CipherViewCellViewModel.cs
@@ -77,6 +77,14 @@ namespace Bit.App.Controls
                 return _cipher.OrganizationId == cozyOrganizationId;
             }
         }
+
+        public string CozySharedImage
+        {
+            get
+            {
+                return _cipher.IsKonnector ? "shared_with_cozy_icon.png" : "login.png";
+            }
+        }
         #endregion
     }
 }

--- a/src/Core/Abstractions/ICozyClientService.cs
+++ b/src/Core/Abstractions/ICozyClientService.cs
@@ -18,5 +18,6 @@ namespace Bit.Core.Abstractions
         string GetRemindCozyAddressUrl(string lang);
         bool CheckStateAndSecretInOnboardingCallbackURL();
         Task UpdateSynchronizedAtAsync();
+        Task<CozyKonnectorsData> GetKonnectorsOrganization();
     }
 }

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -50,6 +50,11 @@ namespace Bit.Core.Models.View
         public DateTime? DeletedDate { get; set; }
         public CipherRepromptType Reprompt { get; set; }
 
+        // Cozy customization, differentiate shared Ciphers from ciphers in "Cozy Connectors" organization
+        //*
+        public bool IsKonnector { get; set; }
+        //*/
+
         public string SubTitle
         {
             get

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -36,19 +36,36 @@ namespace Bit.Core.Utilities
                 messagingService.Send("logout", expired);
                 return Task.FromResult(0);
             }, customUserAgent);
+            // Cozy customization, declare CozyClientService
+            //*
+            var environmentService = new EnvironmentService(apiService, storageService);
+            var cozyClientService = new CozyClientService(tokenService, apiService, environmentService);
+            //*/
+
             var appIdService = new AppIdService(storageService);
             var userService = new UserService(storageService, tokenService);
             var settingsService = new SettingsService(userService, storageService);
             var fileUploadService = new FileUploadService(apiService);
+            // Cozy customization, add CozyClientService in CipherService's constructor
+            /*
             var cipherService = new CipherService(cryptoService, userService, settingsService, apiService, fileUploadService,
                 storageService, i18nService, () => searchService, clearCipherCacheKey, allClearCipherCacheKeys);
+            /*/
+            var cipherService = new CipherService(cryptoService, userService, settingsService, apiService, fileUploadService,
+                storageService, i18nService, () => searchService, clearCipherCacheKey, allClearCipherCacheKeys, cozyClientService);
+            //*/
             var folderService = new FolderService(cryptoService, userService, apiService, storageService,
                 i18nService, cipherService);
             var collectionService = new CollectionService(cryptoService, userService, storageService, i18nService);
             var sendService = new SendService(cryptoService, userService, apiService, fileUploadService, storageService,
                 i18nService, cryptoFunctionService);
+            // Cozy customization, add CozyClientService in SearchService's constructor
+            /*
             searchService = new SearchService(cipherService, sendService);
-            var policyService = new PolicyService(storageService, userService);
+            /*/
+            searchService = new SearchService(cipherService, sendService, cozyClientService);
+            //*/
+            var policyService = new PolicyService(storageService, userService); 
             var vaultTimeoutService = new VaultTimeoutService(cryptoService, userService, platformUtilsService,
                 storageService, folderService, cipherService, collectionService, searchService, messagingService, tokenService,
                 policyService, null, (expired) =>
@@ -56,8 +73,10 @@ namespace Bit.Core.Utilities
                     messagingService.Send("logout", expired);
                     return Task.FromResult(0);
                 });
+            // Cozy customization, declare environmentService earlier so it can be used in CozyClientService constructor
+            /*
             var environmentService = new EnvironmentService(apiService, storageService);
-            var cozyClientService = new CozyClientService(tokenService, apiService, environmentService);
+            //*/
             var syncService = new SyncService(userService, apiService, settingsService, folderService,
                 cipherService, cryptoService, collectionService, storageService, messagingService, policyService, sendService, cozyClientService,
                 (bool expired) =>


### PR DESCRIPTION
⚠️ this PR is in draft mode until we add access autorization on stack to allow Pass Mobile to access settings.

This PR's goal is to differentiate shared ciphers from ciphers that are part of Cozy Connectors

It is related to https://github.com/cozy/cozy-pass-web/pull/69 
___

Todo:
- [ ] Add final `sharing` icon (instead of `login.png` that is used as a placeholder)
- [ ] Clean comments to mark all edits as Cozy customization
- [ ] Test