### PR TITLE
fix: remove folder list on cipher creation

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -533,7 +533,7 @@
             <!-- Cozy customization -->
             <!-- Add Folder (Cozy concept) display and selection -->
             <!---->
-            <StackLayout StyleClass="box" IsVisible="{Binding HasOrganization}">
+            <StackLayout StyleClass="box" IsVisible="{Binding ShowOrganizations}">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n Folder, Header=True}"
                                    StyleClass="box-header, box-header-platform" />

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -313,11 +313,13 @@ namespace Bit.App.Pages
             set => SetProperty(ref _organizationName, value,
                 additionalPropertyNames: new string[]
                 {
-                    nameof(HasOrganization)
+                    nameof(HasOrganization),
+                    nameof(ShowOrganizations)
                 });
         }
 
         public bool HasOrganization => !string.IsNullOrEmpty(_organizationName);
+        public bool ShowOrganizations => HasOrganization && EditMode;
         //*/
 
         public void Init()


### PR DESCRIPTION
Current workflow does not allow to edit cipher's folder before its
creation

This feature is disabled on cipher's creation screen until we adapt the
workflow


___

Future solution would be to edit the SharePage in order to:
- take a boolean that would be true if we open the page un "create" mode
- only set the cipher's organizationId without calling the server when validating the choice
- then the AddEdit page would have to call the correct share method after cipher's creation (or maybe just create it if we can encrypt it directly with the org key).

Another option would be to create a new Page for that process instead of adding complexity to SharePage.