### PR TITLE
fix: avoid word wrapping for single word settings values

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Bit.App.Pages.SettingsPage"
@@ -44,7 +44,9 @@
                            HorizontalTextAlignment="End"
                            VerticalOptions="CenterAndExpand"
                            TextColor="{Binding SubLabelColor}"
-                           StyleClass="list-sub" />
+                           StyleClass="list-sub"
+                           MinimumWidthRequest="100"
+                           LineBreakMode="WordWrap" />
                     <TimePicker IsVisible="{Binding ShowTimeInput}"
                                 Time="{Binding Time}" Format="HH:mm"
                                 PropertyChanged="OnTimePickerPropertyChanged"


### PR DESCRIPTION
When a setting label is single line and its setting value is single line, everything is displayed correctly

When a setting label is multi line and its value is single word, then
the value may not succeed to require enough space and so it may wrap in
the middle of the word and it becomes multi line

When a setting label is multi line and its value is multi words, then
the value succeed to require enough space to be displayed correctly

With `MinimumWidthRequest=100` and `LineBreakMode=WordWrap`, all three
previous cases are displayed correctly without excessive wrapping
___

⚠️ this solution is a hack more than a real solution. Hopefully the `MinimumWidthRequest` does not force the label to have a width of 100 if it is smaller. Sadly I don't really understand why this work 🙃  

It has been tested on Android and iOS and in French and English
___
### Examples (left = previous, right = new, background colors are here to vizualise layout space)
![image](https://user-images.githubusercontent.com/1884255/145610392-911e2635-a707-4789-ab32-625a94a44d72.png) ![image](https://user-images.githubusercontent.com/1884255/145610513-da1439a8-4d21-4f8d-8efc-8ca9b4a8eeea.png)
![image](https://user-images.githubusercontent.com/1884255/145610291-8abdb088-95b3-4207-80ce-9f507138d2c8.png) ![image](https://user-images.githubusercontent.com/1884255/145610456-52d547ba-aba7-43a5-809c-47a579025dae.png)
![image](https://user-images.githubusercontent.com/1884255/145610322-d9279e61-337f-4853-bab0-97a817448750.png) ![image](https://user-images.githubusercontent.com/1884255/145610487-aa6646c3-dfe1-4516-87a1-74f71eec8488.png)
___
### English version is not impacted as it has very concise texts
![image](https://user-images.githubusercontent.com/1884255/145610805-47b9b8ef-0ddd-4f1d-ba30-2686a720176c.png) ![image](https://user-images.githubusercontent.com/1884255/145610833-e6f61900-d358-4583-8780-a932fde217ca.png)
