### PR TITLE
fix: correctly handle params in `CozyClientService.GetURLForApp()`

### DIFF
--- a/src/Core/Services/CozyClientService.cs
+++ b/src/Core/Services/CozyClientService.cs
@@ -225,8 +225,8 @@ namespace Bit.Core.Services
                 cozyUrl: cozyURL,
                 searchParams: null,
                 pathname: "",
-                hash: "/vault?action=import",
-                slug: "passwords",
+                hash: fragment,
+                slug: appName,
                 subDomainType: subdomain
             );
 


### PR DESCRIPTION
In previous commit `GetURLForApp()` has been refactored to handle
nested domains vs flat domains

During this refactor, params have been forced with values from
`SettingsPageViewModel.Import()` method which was a mistake

This broke `SettingsPageViewModel.TwoStepAsync()` method that would
redirect to Cozy Pass import page instead of Cozy Settings page

Params are now correctly passed to `UrlHelper.GenerateWebLink()`

Related commit: b3d84a116ccac7117cc38f70736a5c41a4755ac1