### PR TITLE
feat: improve `move to folder` description

### DIFF
--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -1461,7 +1461,7 @@
     <value>Aucun dossier à afficher.</value>
   </data>
   <data name="MoveToOrgDesc" xml:space="preserve">
-    <value>Choisissez un dossier dans lequel vous souhaitez ranger cet élément.&#10;&#10;Astuce : en sélectionnant un dossier partagé, vous pourrez ainsi transmettre cet élément de manière sécurisé à d'autres utilisateurs qui possèdent un Cozy.</value>
+    <value>Choisissez un dossier dans lequel vous souhaitez ranger cet élément.&#10;&#10;Astuce : en sélectionnant un dossier partagé, vous pourrez ainsi transmettre cet élément de manière sécurisé à d'autres utilisateurs qui possèdent un Cozy. Pour créer un dossier partagé, vous devez vous rendre sur l'interface web de Cozy Pass.</value>
   </data>
   <data name="NumberOfWords" xml:space="preserve">
     <value>Nombre de mots</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1461,7 +1461,7 @@
     <value>No folder to list.</value>
   </data>
   <data name="MoveToOrgDesc" xml:space="preserve">
-    <value>Choose a folder to store this item.&#10;&#10;Tips: after selecting a shared folder, you will be able to securely share this element with other Cozy users.</value>
+    <value>Choose a folder to store this item.&#10;&#10;Tips: after selecting a shared folder, you will be able to securely share this element with other Cozy users. You can create a shared folder by using the web version of Cozy Pass.</value>
   </data>
   <data name="NumberOfWords" xml:space="preserve">
     <value>Number of Words</value>


### PR DESCRIPTION
Users cannot create a shared folder from the Mobile app, so we add
instruction on how to do it from the web interface