### PR TITLE
feat: re-enable notes

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -599,9 +599,6 @@
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" />
             </StackLayout>
-            <!-- Cozy customization -->
-            <!-- Notes are disabled to avoid confusion with Cozy Notes -->
-            <!--
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n Notes, Header=True}"
@@ -616,7 +613,6 @@
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowNotesSeparator}" />
             </StackLayout>
-            -->
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n CustomFields, Header=True}"

--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -340,7 +340,7 @@
     <value>Non</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>Notes</value>
+    <value>Description</value>
     <comment>Label for notes.</comment>
   </data>
   <data name="Ok" xml:space="preserve">

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -340,7 +340,7 @@
     <value>No</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>Notes</value>
+    <value>Description</value>
     <comment>Label for notes.</comment>
   </data>
   <data name="Ok" xml:space="preserve">


### PR DESCRIPTION
Notes were disabled to avoid confusion with Cozy Notes

We enable them again but named as `Description`

Related commit: 0c2fd0d0560fc19df15560751b6176b7ad7e8080