### PR TITLE
feat: edit `move to folder` description

### DIFF
--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -1461,7 +1461,7 @@
     <value>Aucun dossier à afficher.</value>
   </data>
   <data name="MoveToOrgDesc" xml:space="preserve">
-    <value>Choisissez un dossier dans lequel vous souhaitez ranger cet élément.&#10;&#10;Astuce : en sélectionnant un dossier partagé, vous pourrez ainsi transmettre cet élément de manière sécurisé à d'autres utilisateurs qui possèdent un Cozy. Pour créer un dossier partagé, vous devez vous rendre sur l'interface web de Cozy Pass.</value>
+    <value>Choisissez un dossier dans lequel vous souhaitez ranger cet élément.&#10;&#10;Astuce : en sélectionnant un dossier partagé, vous pourrez ainsi transmettre cet élément de manière sécurisé à d'autres utilisateurs qui possèdent un Cozy. Pour créer un dossier partagé, vous devez vous rendre sur l'interface web de Cozy Pass (si votre Cozy le permet).</value>
   </data>
   <data name="NumberOfWords" xml:space="preserve">
     <value>Nombre de mots</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1461,7 +1461,7 @@
     <value>No folder to list.</value>
   </data>
   <data name="MoveToOrgDesc" xml:space="preserve">
-    <value>Choose a folder to store this item.&#10;&#10;Tips: after selecting a shared folder, you will be able to securely share this element with other Cozy users. You can create a shared folder by using the web version of Cozy Pass.</value>
+    <value>Choose a folder to store this item.&#10;&#10;Tips: after selecting a shared folder, you will be able to securely share this element with other Cozy users. You can create a shared folder by using the web version of Cozy Pass (if the feature is enabled on your Cozy).</value>
   </data>
   <data name="NumberOfWords" xml:space="preserve">
     <value>Number of Words</value>


### PR DESCRIPTION
As folders creation and sharing is still behind a flag, we specify that the feature may not be available for the user.