### PR TITLE
fix: force image crop on iOS on Lock page

### DIFF
--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -74,7 +74,8 @@
                            CornerRadius="40"
                            BackgroundColor="LightGray"
                            WidthRequest="80"
-                           HeightRequest="80">
+                           HeightRequest="80"
+                           IsClippedToBounds="True">
                         <Image Source="{Binding AvatarUrl}"
                                Margin="-1,-1,-1,-1"
                                WidthRequest="80"


### PR DESCRIPTION
Frame component has a different behavior when running on iOS compared
to Android

When `CornerRadius` property is set, then Android applies a crop on
the image which is contained inside of the rounded corners

On iOS this crop is not applied until `IsClippedToBounds` property is
set to `True`