### PR TITLE
Fix/ios autofill theme

### DIFF
--- a/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
@@ -34,6 +34,7 @@ namespace Bit.App.Pages
 
         protected async override void OnAppearing()
         {
+            ThemeManager.UnsetInvertedTheme();
             base.OnAppearing();
             if (!await AppHelpers.IsVaultTimeoutImmediateAsync())
             {

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -10,6 +10,7 @@ using Bit.iOS.Core.Utilities;
 using Bit.Core.Utilities;
 using Bit.Core.Abstractions;
 using Bit.App.Abstractions;
+using Bit.App.Utilities;
 
 namespace Bit.iOS.Autofill
 {
@@ -28,6 +29,7 @@ namespace Bit.iOS.Autofill
 
         public async override void ViewDidLoad()
         {
+            ThemeManager.UnsetInvertedTheme();
             base.ViewDidLoad();
             NavItem.Title = AppResources.Items;
             CancelBarButton.Title = AppResources.Cancel;

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UIKit;
 using Foundation;
 using Bit.iOS.Core.Views;
@@ -49,6 +49,7 @@ namespace Bit.iOS.Core.Controllers
 
         public override async void ViewDidLoad()
         {
+            ThemeManager.SetInvertedTheme();
             _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
             _cryptoService = ServiceContainer.Resolve<ICryptoService>("cryptoService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
@@ -105,13 +106,13 @@ namespace Bit.iOS.Core.Controllers
 
             // Cozy customization, change unlock form style to match inverted theme
             //*
-            MasterPasswordCell.TextField.BackgroundColor = ThemeHelpers.PrimaryColor;
-            MasterPasswordCell.TextField.TextColor = ThemeHelpers.BackgroundColor;
-            MasterPasswordCell.TextField.TintColor = ThemeHelpers.BackgroundColor;
-            MasterPasswordCell.Label.TextColor = ThemeHelpers.BackgroundColor;
-            MasterPasswordCell.BackgroundColor = ThemeHelpers.PrimaryColor;
-            TableView.BackgroundColor = ThemeHelpers.PrimaryColor;
-            TableView.SeparatorColor = ThemeHelpers.BackgroundColor;
+            MasterPasswordCell.TextField.BackgroundColor = ThemeHelpers.BackgroundColor;
+            MasterPasswordCell.TextField.TextColor = ThemeHelpers.PrimaryColor;
+            MasterPasswordCell.TextField.TintColor = ThemeHelpers.PrimaryColor;
+            MasterPasswordCell.Label.TextColor = ThemeHelpers.PrimaryColor;
+            MasterPasswordCell.BackgroundColor = ThemeHelpers.BackgroundColor;
+            TableView.BackgroundColor = ThemeHelpers.BackgroundColor;
+            TableView.SeparatorColor = ThemeHelpers.PrimaryColor;
             //*/
 
             if (_biometricLock)


### PR DESCRIPTION
This PR fixes how inverted theme is handled by Autofill screens on iOS and Android

### Autofill on iOS using Dark theme:
![image](https://user-images.githubusercontent.com/1884255/149813907-bb8e3f63-e2e5-46c5-8304-034d4a38e586.png)
![image](https://user-images.githubusercontent.com/1884255/149814795-067dabf0-c445-40db-a82a-ca947cf46d68.png)


### Autofill on Android using White theme
![image](https://user-images.githubusercontent.com/1884255/149814712-ee0d0367-dce0-495f-a1cf-0362464883b0.png)
![image](https://user-images.githubusercontent.com/1884255/149814560-f1937709-889e-4327-8ae4-d7423fe3c723.png)
