### PR TITLE
fix: Prevent app crash when opened from URL scheme in iOS 15+

### DIFF
--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -261,11 +261,7 @@ namespace Bit.iOS
 
         public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
         {
-            if (Xamarin.Essentials.Platform.OpenUrl(app, url, options))
-            {
-                return true;
-            }
-            return base.OpenUrl(app, url, options);
+            return Xamarin.Essentials.Platform.OpenUrl(app, url, options);
         }
 
         public override bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity,


### PR DESCRIPTION
On iOS 15+ the app crashes when opened from URL scheme (i.e. when
opened from our mobile flagship app)

This is because calling  base's OpenUrl method is not allowed here, so
we just removed this call

Related PR: bitwarden/mobile#1850
Related Issue: MicrosoftDocs/xamarin-docs#3377
Related PR: MicrosoftDocs/xamarin-docs#3437

____

This change has been tested on :
- Android 10 - api 29
- iOS 15.5
- iOS 14.5