### PR TITLE
feat: bump version to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 3.0.2
+
+## ✨ Features
+
+## 🐛 Bug Fixes
+
+* Prevent app crash when opened from URL scheme in iOS 15+ ([PR #75](https://github.com/cozy/cozy-pass-mobile/pull/75))
+
+## 🔧 Tech
+
+# 3.0.1
+
+## ✨ Features
+
+## 🐛 Bug Fixes
+
+* Force image crop on iOS on `unlock` screen ([PR #71](https://github.com/cozy/cozy-pass-mobile/pull/71))
+* Fix iOS `autofill` theme ([PR #73](https://github.com/cozy/cozy-pass-mobile/pull/73))
+
+## 🔧 Tech
+
 # 3.0.0
 
 ## ✨ Features

--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  android:versionCode="3000010"
-  android:versionName="3.0.0"
+  android:versionCode="3000200"
+  android:versionName="3.0.2"
   android:installLocation="internalOnly"
   package="io.cozy.pass">
 

--- a/src/iOS.Autofill/Info.plist
+++ b/src/iOS.Autofill/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.autofill</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.2</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -70,8 +70,8 @@
 		<string>FontAwesome.ttf</string>
 		<string>MaterialIcons_Regular.ttf</string>
 	</array>
-    <key>CADisableMinimumFrameDurationOnPhone</key>
-    <true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<dict>
 		<key>arm64</key>
@@ -96,6 +96,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>3000010</string>
+	<string>3000200</string>
 </dict>
 </plist>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.find-login-action-extension</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.2</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -70,8 +70,8 @@
 		<string>FontAwesome.ttf</string>
 		<string>MaterialIcons_Regular.ttf</string>
 	</array>
-    <key>CADisableMinimumFrameDurationOnPhone</key>
-    <true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<dict>
 		<key>arm64</key>
@@ -113,6 +113,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>3000010</string>
+	<string>3000200</string>
 </dict>
 </plist>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.2</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleURLTypes</key>
@@ -111,8 +111,8 @@
 		<key>arm64</key>
 		<true/>
 	</dict>
-    <key>CADisableMinimumFrameDurationOnPhone</key>
-    <true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Assets.xcassets/AppIcons.appiconset</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
@@ -137,6 +137,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>3000010</string>
+	<string>3000200</string>
 </dict>
 </plist>


### PR DESCRIPTION
Bump to `3.0.2` in order to release https://github.com/cozy/cozy-pass-mobile/pull/75 fix on iOS

`3.0.2` will only be released on iOS as Android isn't impacted by the fix. However both platforms' versions have been bumped