### PR TITLE
fix: Prevent app crash when scrolling grouped collection view in iOS 15+

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
+    <PackageReference Include="Xamarin.CommunityToolkit" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -434,5 +435,8 @@
     <Reference Include="Xamarin.iOS" Condition=" '$(OS)' == 'Windows_NT' AND '$(VisualStudioVersion)' == '16.0' ">
       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\Xamarin.iOS\v1.0\Xamarin.iOS.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Xamarin.CommunityToolkit" />
   </ItemGroup>
 </Project>

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -124,8 +124,7 @@
                                     Spacing="0" Padding="0" VerticalOptions="FillAndExpand"
                                     StyleClass="list-row-header-container, list-row-header-container-platform">
                                     <BoxView
-                                        StyleClass="list-section-separator-top, list-section-separator-top-platform"
-                                        IsVisible="{Binding First, Converter={StaticResource inverseBool}}" />
+                                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
                                     <StackLayout StyleClass="list-row-header, list-row-header-platform">
                                         <Label
                                             Text="{Binding Name}"

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Xamarin.Forms;
+using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace Bit.App.Pages
 {
@@ -77,11 +78,11 @@ namespace Bit.App.Pages
             _cozyClientService = ServiceContainer.Resolve<ICozyClientService>("cozyClientService");
             _i18nService = ServiceContainer.Resolve<II18nService>("i18nService");
 
-            GroupedItems = new ExtendedObservableCollection<SettingsPageListGroup>();
+            GroupedItems = new ObservableRangeCollection<SettingsPageListGroup>();
             PageTitle = AppResources.Settings;
         }
 
-        public ExtendedObservableCollection<SettingsPageListGroup> GroupedItems { get; set; }
+        public ObservableRangeCollection<SettingsPageListGroup> GroupedItems { get; set; }
 
         public async Task InitAsync()
         {
@@ -394,6 +395,8 @@ namespace Bit.App.Pages
 
         public void BuildList()
         {
+            GroupedItems.Clear();
+
             var doUpper = Device.RuntimePlatform != Device.Android;
             var autofillItems = new List<SettingsPageListItem>();
             if (Device.RuntimePlatform == Device.Android)
@@ -497,7 +500,7 @@ namespace Bit.App.Pages
                 new SettingsPageListItem { Name = AppResources.Help },
                 new SettingsPageListItem { Name = AppResources.RateTheApp }
             };
-            GroupedItems.ResetWithRange(new List<SettingsPageListGroup>
+            GroupedItems.AddRange(new List<SettingsPageListGroup>
             {
                 new SettingsPageListGroup(autofillItems, AppResources.Autofill, doUpper, true),
                 new SettingsPageListGroup(manageItems, AppResources.Manage, doUpper),

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -106,8 +106,7 @@
                                     Spacing="0" Padding="0" VerticalOptions="FillAndExpand"
                                     StyleClass="list-row-header-container, list-row-header-container-platform">
                                     <BoxView
-                                        StyleClass="list-section-separator-top, list-section-separator-top-platform"
-                                        IsVisible="{Binding First, Converter={StaticResource inverseBool}}" />
+                                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
                                     <StackLayout StyleClass="list-row-header, list-row-header-platform">
                                         <Label
                                             Text="{Binding Name}"


### PR DESCRIPTION
On iOS 15+ scroll views would use a different calculation algorithm for
auto cell sizes, which may result in infinite loops and app crash

This commit is retrieved from bitwarden official project

Related PR: bitwarden/mobile#1842