### PR TITLE
feat: bump version to 3.0.4 and add accessibility service disclosure prompt for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.0.4
+
+## ✨ Features
+
+* Rework of the login UI ([PR #86](https://github.com/cozy/cozy-pass-mobile/pull/86))
+
+## 🐛 Bug Fixes
+
+* Prevent app crash when scrolling in cipers and settings pages in iOS 15+ ([PR #77](https://github.com/cozy/cozy-pass-mobile/pull/77))
+* Disable the Register button on HomePage ([PR #84](https://github.com/cozy/cozy-pass-mobile/pull/84))
+
+## 🔧 Tech
+
+* Upgrade Android SDK to 12.1 ([PR #87](https://github.com/cozy/cozy-pass-mobile/pull/87))
+
 # 3.0.3
 
 ## ✨ Features
@@ -5,6 +20,7 @@
 ## 🐛 Bug Fixes
 
 * Prevent app crash when scrolling in cipers and settings pages in iOS 15+ ([PR #77](https://github.com/cozy/cozy-pass-mobile/pull/77))
+* Disable the Register button on HomePage ([PR #84](https://github.com/cozy/cozy-pass-mobile/pull/84))
 
 ## 🔧 Tech
 

--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  android:versionCode="3000300"
-  android:versionName="3.0.3"
+  android:versionCode="3000401"
+  android:versionName="3.0.4"
   android:installLocation="internalOnly"
   package="io.cozy.pass">
 

--- a/src/Android/Resources/xml/accessibilityservice.xml
+++ b/src/Android/Resources/xml/accessibilityservice.xml
@@ -6,4 +6,5 @@
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows"
     android:notificationTimeout="100"
-    android:canRetrieveWindowContent="true"/>
+    android:canRetrieveWindowContent="true"
+    android:isAccessibilityTool="false"/>

--- a/src/App/Pages/Settings/AutofillServicesPage.xaml
+++ b/src/App/Pages/Settings/AutofillServicesPage.xaml
@@ -83,7 +83,7 @@
                             StyleClass="box-value"
                             HorizontalOptions="End" />
                         <Button
-                            Clicked="ToggleAccessibility"
+                            Command="{Binding ToggleAccessibilityCommand}"
                             StyleClass="box-overlay"
                             RelativeLayout.XConstraint="0"
                             RelativeLayout.YConstraint="0"

--- a/src/App/Pages/Settings/AutofillServicesPage.xaml.cs
+++ b/src/App/Pages/Settings/AutofillServicesPage.xaml.cs
@@ -55,14 +55,6 @@ namespace Bit.App.Pages
             _vm.ToggleInlineAutofill();
         }
         
-        private void ToggleAccessibility(object sender, EventArgs e)
-        {
-            if (DoOnce())
-            {
-                _vm.ToggleAccessibility();
-            }
-        }
-        
         private void ToggleDrawOver(object sender, EventArgs e)
         {
             if (DoOnce())

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -79,6 +79,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Accept.
+        /// </summary>
+        public static string Accept {
+            get {
+                return ResourceManager.GetString("Accept", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à By activating this switch you agree to the following:
         ///.
         /// </summary>
@@ -143,11 +152,29 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Cozy Pass uses the Accessibility Service to search for login fields in apps and websites, then establish the appropriate field IDs for entering a username &amp; password when a match for the app or site is found. We do not store any of the information presented to us by the service, nor do we make any attempt to control any on-screen elements beyond text entry of credentials..
+        /// </summary>
+        public static string AccessibilityDisclosureText {
+            get {
+                return ResourceManager.GetString("AccessibilityDisclosureText", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Bitwarden needs attention - Enable &quot;Draw-Over&quot; in &quot;Auto-fill Services&quot; from Bitwarden Settings.
         /// </summary>
         public static string AccessibilityDrawOverPermissionAlert {
             get {
                 return ResourceManager.GetString("AccessibilityDrawOverPermissionAlert", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Accessibility Service Disclosure.
+        /// </summary>
+        public static string AccessibilityServiceDisclosure {
+            get {
+                return ResourceManager.GetString("AccessibilityServiceDisclosure", resourceCulture);
             }
         }
         
@@ -1399,6 +1426,15 @@ namespace Bit.App.Resources {
         public static string December {
             get {
                 return ResourceManager.GetString("December", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Decline.
+        /// </summary>
+        public static string Decline {
+            get {
+                return ResourceManager.GetString("Decline", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2127,5 +2127,17 @@
   </data>
   <data name="PurchasePremiumMembership" xml:space="preserve">
     <value>Adhésion Premium</value>
+  </data>
+  <data name="AccessibilityServiceDisclosure" xml:space="preserve">
+    <value>Confidentialité du Service d'accessibilité</value>
+  </data>
+  <data name="AccessibilityDisclosureText" xml:space="preserve">
+    <value>Cozy Pass utilise le Service d'Accessibilité pour rechercher des champs de connexion dans les applis et les sites web, puis trouvent les IDs des champs liés pour saisir un nom d'utilisateur et un mot de passe lorsqu'une correspondance pour l'appli ou le site est trouvée. Nous ne stockons aucune information que nous recevons via le service, et nous n'essayons pas de contrôler des éléments qui se superposeraient aux entrées de saisie des identifiants.</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Accepter</value>
+  </data>
+  <data name="Decline" xml:space="preserve">
+    <value>Refuser</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2129,4 +2129,16 @@
   <data name="PurchasePremiumMembership" xml:space="preserve">
     <value>Premium Membership</value>
   </data>
+  <data name="AccessibilityServiceDisclosure" xml:space="preserve">
+    <value>Accessibility Service Disclosure</value>
+  </data>
+  <data name="AccessibilityDisclosureText" xml:space="preserve">
+    <value>Cozy Pass uses the Accessibility Service to search for login fields in apps and websites, then establish the appropriate field IDs for entering a username &amp; password when a match for the app or site is found. We do not store any of the information presented to us by the service, nor do we make any attempt to control any on-screen elements beyond text entry of credentials.</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Accept</value>
+  </data>
+  <data name="Decline" xml:space="preserve">
+    <value>Decline</value>
+  </data>
 </root>

--- a/src/iOS.Autofill/Info.plist
+++ b/src/iOS.Autofill/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.autofill</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -96,6 +96,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>3000306</string>
+	<string>3000400</string>
 </dict>
 </plist>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile.find-login-action-extension</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
@@ -113,6 +113,6 @@
 		<string>com.apple.ui-services</string>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>3000306</string>
+	<string>3000400</string>
 </dict>
 </plist>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>io.cozy.pass.mobile</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleURLTypes</key>
@@ -137,6 +137,6 @@
 		</dict>
 	</dict>
 	<key>CFBundleVersion</key>
-	<string>3000306</string>
+	<string>3000400</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR bumps the app to 3.0.4

### feat: Add accessibility service disclosure prompt for Android

Now that we're targeting API 32 we're required to comply with Google
new policy regarding non-accessibility apps using accessibility
services. This PR adds the disclosure and consent prompt as described
on the help page.

https://support.google.com/googleplay/android-developer/answer/10964491

This PR is a partial cherry pick from Bitwarden's changes

Related PR: bitwarden/mobile#2102
Related PR: bitwarden/mobile#2104