### PR TITLE
feat: Add device's name to OAuth client name and fix logout

### DIFF
--- a/src/Core/Abstractions/ITokenService.cs
+++ b/src/Core/Abstractions/ITokenService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -28,9 +28,9 @@ namespace Bit.Core.Abstractions
         int TokenSecondsRemaining();
 
         #region cozy
-        string ClientId { get; }
-        string RegistrationAccessToken { get; }
-        void SetClientInfos(string clientId, string registrationAccessToken);
+        Task SetClientInfos(string clientId, string registrationAccessToken);
+        Task<string> GetClientId();
+        Task<string> GetRegistrationAccessToken();
         #endregion
     }
 }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />
     <PackageReference Include="zxcvbn-core" Version="7.0.92" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Models/Request/TokenRequest.cs
+++ b/src/Core/Models/Request/TokenRequest.cs
@@ -1,9 +1,10 @@
-﻿using Bit.Core.Enums;
+using Bit.Core.Enums;
 using Bit.Core.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Text;
+using Xamarin.Essentials;
 
 namespace Bit.Core.Models.Request
 {
@@ -49,7 +50,7 @@ namespace Bit.Core.Models.Request
                 ["client_id"] = clientId,
 
                 #region cozy
-                ["clientName"] = "Cozy Pass"
+                ["clientName"] = $"Cozy Pass ({DeviceInfo.Name})"
                 #endregion cozy
             };
 

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Abstractions;
+using Bit.Core.Abstractions;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.Request;
@@ -582,7 +582,7 @@ namespace Bit.Core.Services
                 await _tokenService.SetTokensAsync(tokenResponse.AccessToken, tokenResponse.RefreshToken);
 
                 #region cozy
-                _tokenService.SetClientInfos(tokenResponse.ClientId, tokenResponse.RegistrationAccessToken);
+                await _tokenService.SetClientInfos(tokenResponse.ClientId, tokenResponse.RegistrationAccessToken);
                 #endregion
 
                 return tokenResponse;

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Abstractions;
+using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Domain;
@@ -350,7 +350,7 @@ namespace Bit.Core.Services
             }
 
             #region cozy
-            _tokenService.SetClientInfos(tokenResponse.ClientId, tokenResponse.RegistrationAccessToken);
+            await _tokenService.SetClientInfos(tokenResponse.ClientId, tokenResponse.RegistrationAccessToken);
             #endregion
 
             await _tokenService.SetTokensAsync(tokenResponse.AccessToken, tokenResponse.RefreshToken);

--- a/src/Core/Services/CozyClientService.cs
+++ b/src/Core/Services/CozyClientService.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Abstractions;
+using Bit.Core.Abstractions;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Response;
 using Newtonsoft.Json;
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Bit.Core.Utilities;
+using Xamarin.Essentials;
 
 namespace Bit.Core.Services
 {
@@ -278,7 +279,7 @@ namespace Bit.Core.Services
             var data = new
             {
                 software_id = softwareID,
-                client_name = "Cozy Pass",
+                client_name = $"Cozy Pass ({DeviceInfo.Name})",
                 client_kind = "mobile",
                 logo_uri = logoURI,
                 policy_uri = policyURI,

--- a/src/Core/Services/CozyClientService.cs
+++ b/src/Core/Services/CozyClientService.cs
@@ -136,8 +136,8 @@ namespace Bit.Core.Services
         }
 
         public async Task<LogoutResponse> LogoutAsync() {
-            var clientId = _tokenService.ClientId;
-            var registrationAccessToken = _tokenService.RegistrationAccessToken;
+            var clientId = await _tokenService.GetClientId();
+            var registrationAccessToken = await _tokenService.GetRegistrationAccessToken();
             try
             {
                 var resp = await FetchJSONAsync<object, LogoutResponse>(

--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -17,6 +17,8 @@ namespace Bit.Core.Services
 
         private const string Keys_AccessToken = "accessToken";
         private const string Keys_RefreshToken = "refreshToken";
+        private const string Keys_RegistrationAccessToken = "cozyRegistrationAccessToken";
+        private const string Keys_ClientId = "cozyClientId";
         private const string Keys_TwoFactorTokenFormat = "twoFactorToken_{0}";
 
         public TokenService(IStorageService storageService)
@@ -116,7 +118,9 @@ namespace Bit.Core.Services
             _refreshToken = null;
             await Task.WhenAll(
                 _storageService.RemoveAsync(Keys_AccessToken),
-                _storageService.RemoveAsync(Keys_RefreshToken));
+                _storageService.RemoveAsync(Keys_RefreshToken),
+                _storageService.RemoveAsync(Keys_ClientId),
+                _storageService.RemoveAsync(Keys_RegistrationAccessToken));
         }
 
         public JObject DecodeToken()
@@ -238,13 +242,31 @@ namespace Bit.Core.Services
         }
 
         #region cozy
-        public string RegistrationAccessToken { get; private set; }
-        public string ClientId { get; private set; }
-
-        public void SetClientInfos(string clientId, string registrationAccessToken)
+        public async Task SetClientInfos(string clientId, string registrationAccessToken)
         {
-            ClientId = clientId;
-            RegistrationAccessToken = registrationAccessToken;
+            await SetClientId(clientId);
+            await SetRegistrationAccessToken(registrationAccessToken);
+
+        }
+
+        private async Task SetClientId(string registrationAccessToken)
+        {
+            await _storageService.SaveAsync(Keys_ClientId, registrationAccessToken);
+        }
+
+        public async Task<string> GetClientId()
+        {
+            return await _storageService.GetAsync<string>(Keys_ClientId);
+        }
+
+        private async Task SetRegistrationAccessToken(string registrationAccessToken)
+        {
+            await _storageService.SaveAsync(Keys_RegistrationAccessToken, registrationAccessToken);
+        }
+
+        public async Task<string> GetRegistrationAccessToken()
+        {
+            return await _storageService.GetAsync<string>(Keys_RegistrationAccessToken);
         }
         #endregion
     }


### PR DESCRIPTION
### feat: Add device's name to OAuth client name

With current implementation, the Cozy's Connected Devices list would display `Cozy Pass`, `Cozy Pass (2)`,  `Cozy Pass (3)` etc for each new connected device

To improve this, we add the device's name to the client name. So it would become `Cozy Pass (Claude's phone)`, `Cozy Pass (iPhone 13)` etc

____

### fix: Persist `ClientId` and `RegistrationAccessToken` for logout

We want the Cozy's OAuth client to be deleted when the user logs out from the app

With current implementation, the OAuth client can be deleted only if the logout is done in the same runtime session than when the login has been done. If the app is closed, then the `clientId` and `registrationAccessToken` are lost and we won't be able to delete it anymore

While `clientId` can be recovered from the persisted token, the `registrationAccessToken` cannot be recovered. It is definitively lost

To prevent this, we want to persist this info

Related commit: e0ffa2fe6a41f020c4e17adf28ca45b203fcce76