### PR TITLE
feat: Implement ClouderyEnv override using links

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Bit.App.Abstractions;
+using Bit.App.Abstractions;
 using Bit.App.Models;
 using Bit.App.Pages;
 using Bit.App.Pages.Accounts;
@@ -29,6 +29,7 @@ namespace Bit.App
         private readonly IStorageService _storageService;
         private readonly IStorageService _secureStorageService;
         private readonly IDeviceActionService _deviceActionService;
+        private readonly ICozyClouderyEnvService _cozyClouderyEnvService;
 
         private static bool _isResumed;
 
@@ -51,6 +52,7 @@ namespace Bit.App
             _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _secureStorageService = ServiceContainer.Resolve<IStorageService>("secureStorageService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            _cozyClouderyEnvService = ServiceContainer.Resolve<ICozyClouderyEnvService>("cozyClouderyEnvService");
 
             Bootstrap();
             _broadcasterService.Subscribe(nameof(App), async (message) =>
@@ -227,6 +229,10 @@ namespace Bit.App
             else if (uri.LocalPath == "/onboarding" && !string.IsNullOrEmpty(onboardingUrl))
             {
                 await HandleOnboardingLink(onboardingUrl);
+            }
+            else if (uri.LocalPath == "/cozy_env_override")
+            {
+                await CozyEnvironmentOverride.ExtractEnvFromUrl(uri, _cozyClouderyEnvService);
             }
         }
         //*/

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -25,6 +25,7 @@ namespace Bit.App.Pages
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly II18nService _i18nService;
         private readonly ICozyClientService _cozyClientService;
+        private readonly ICozyClouderyEnvService _cozyClouderyEnvService;
 
         public HomePage(AppOptions appOptions = null)
         {
@@ -33,6 +34,7 @@ namespace Bit.App.Pages
             _i18nService = ServiceContainer.Resolve<II18nService>("i18nService");
             _cozyClientService = ServiceContainer.Resolve<ICozyClientService>("cozyClientService");
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>("broadcasterService");
+            _cozyClouderyEnvService = ServiceContainer.Resolve<ICozyClouderyEnvService>("cozyClouderyEnvService");
 
             _messagingService.Send("showStatusBar", false);
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>("broadcasterService");
@@ -158,11 +160,7 @@ namespace Bit.App.Pages
         //*
         private async Task StartLoginAsync()
         {
-            var clouderyBaseUri = "https://manager.cozycloud.cc";
-            var clouderyLoginRelativeUri = "/v2/neutral/start";
-            var clouderyQueryString = "redirect_after_email=cozypass%3A%2F%2Fpass%2Fonboarding&redirect_after_login=cozypass%3A%2F%2Fpass%2Flogin";
-
-            var url = $"{clouderyBaseUri}{clouderyLoginRelativeUri}?{clouderyQueryString}";
+            var url = await _cozyClouderyEnvService.GetClouderyUrl();
 
             await Browser.OpenAsync(url, new BrowserLaunchOptions
             {

--- a/src/App/Utilities/CozyEnvironmentOverride.cs
+++ b/src/App/Utilities/CozyEnvironmentOverride.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using Bit.App.Resources;
+using Bit.Core.Abstractions;
+using Flurl;
+
+namespace Bit.App.Utilities
+{
+    public static class CozyEnvironmentOverride
+    {
+        public static async Task ExtractEnvFromUrl(Url uri, ICozyClouderyEnvService cozyClouderyEnvService)
+        {
+            var clouderyEnv = cozyClouderyEnvService.ParseClouderyEnvFromUrl(uri);
+
+            if (!String.IsNullOrEmpty(clouderyEnv))
+            {
+                await cozyClouderyEnvService.SaveClouderyEnvOnAsyncStorage(clouderyEnv);
+                await AlertNewEnvironment(cozyClouderyEnvService);
+            }
+        }
+
+        private static async Task AlertNewEnvironment(ICozyClouderyEnvService cozyClouderyEnvService)
+        {
+            var environmentString = await cozyClouderyEnvService.GetClouderyEnvFromAsyncStorage();
+            await App.Current.MainPage.DisplayAlert(
+                "Environment",
+                $"Environment has been overriden\n\n{environmentString}",
+                AppResources.Ok
+            );
+        }
+    }
+}

--- a/src/Core/Abstractions/ICozyClouderyEnvService.cs
+++ b/src/Core/Abstractions/ICozyClouderyEnvService.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Flurl;
+
+namespace Bit.Core.Abstractions
+{
+    public interface ICozyClouderyEnvService
+    {
+        string ParseClouderyEnvFromUrl(Url uri);
+
+        Task<string> GetClouderyUrl();
+
+        Task<string> GetClouderyEnvFromAsyncStorage();
+        Task SaveClouderyEnvOnAsyncStorage(string clouderyEnv);
+    }
+}

--- a/src/Core/Services/CozyClouderyEnvService.cs
+++ b/src/Core/Services/CozyClouderyEnvService.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bit.Core.Abstractions;
+using Flurl;
+
+namespace Bit.Core.Services
+{
+    public class CozyClouderyEnvService: ICozyClouderyEnvService
+    {
+        private const string Keys_ClouderyEnvConfig = "cozyClouderyEnvConfig";
+
+        private const string DEFAULT_ENV = "PROD";
+
+        private const string PROD_BASE_URI = "https://manager.cozycloud.cc";
+        private const string INT_BASE_URI = "https://staging-manager.cozycloud.cc";
+        private const string DEV_BASE_URI = "https://manager-dev.cozycloud.cc";
+
+        private const string LOGIN_RELATIVE_URI = "/v2/neutral/start";
+
+        private const string QUERY_STRING = "redirect_after_email=cozypass%3A%2F%2Fpass%2Fonboarding&redirect_after_login=cozypass%3A%2F%2Fpass%2Flogin";
+
+        private readonly IStorageService _storageService;
+
+        public CozyClouderyEnvService(IStorageService storageService)
+        {
+            _storageService = storageService;
+        }
+
+        /// <summary>
+        /// Get Cloudery URL to be used on Login InAppBrowser
+        ///
+        /// The returned URL depends on the current app configuration (PROD, INT, DEV)
+        /// </summary>
+        /// <returns>The Cloudery URL</returns>
+        public async Task<string> GetClouderyUrl()
+        {
+            var clouderyEnv = await GetClouderyEnvFromAsyncStorage();
+
+            var baseUris = new Dictionary<string, string>() {
+                { "PROD", PROD_BASE_URI },
+                { "INT", INT_BASE_URI },
+                { "DEV", DEV_BASE_URI },
+            };
+            var baseUri = baseUris[clouderyEnv];
+
+            var clouderyUrl = $"{baseUri}{LOGIN_RELATIVE_URI}?{QUERY_STRING}";
+
+            return clouderyUrl;
+        }
+
+        /// <summary>
+        /// Parse the given deep link URL and extract Cloudery Environment from it
+        /// </summary>
+        /// <param name="uri">URL received from deep link feature</param>
+        /// <returns>The extracted Cloudery Environment (PROD, INT, DEV), or null if none was found</returns>
+        public string ParseClouderyEnvFromUrl(Url uri)
+        {
+            var queryString = uri.Query;
+            var queryDictionary = System.Web.HttpUtility.ParseQueryString(queryString);
+
+            var clouderyEnv = queryDictionary.Get("cloudery_environment");
+
+            if (!IsClouderyEnv(clouderyEnv))
+            {
+                return null;
+            }
+
+            return clouderyEnv;
+        }
+
+        /// <summary>
+        /// Save the given Cloudery Environment (PROD, INT, DEV) in AsyncStorage
+        /// </summary>
+        /// <param name="clouderyEnv">The Cloudery Environment to be saved</param>
+        /// <returns></returns>
+        public async Task SaveClouderyEnvOnAsyncStorage(string clouderyEnv)
+        {
+            await _storageService.SaveAsync(Keys_ClouderyEnvConfig, clouderyEnv);
+        }
+
+        /// <summary>
+        /// Get the Cloudery Environment (PROD, INT, DEV) stored in AsyncStorage
+        /// </summary>
+        /// <returns>The Cloudery Environment (PROD, INT, DEV)</returns>
+        public async Task<string> GetClouderyEnvFromAsyncStorage()
+        {
+            var clouderyEnv = await _storageService.GetAsync<string>(Keys_ClouderyEnvConfig);
+
+            if (!IsClouderyEnv(clouderyEnv))
+            {
+                return DEFAULT_ENV;
+            }
+
+            return clouderyEnv;
+        }
+
+        private bool IsClouderyEnv(string value)
+        {
+            return value == "PROD" || value == "INT" || value == "DEV";
+        }
+    }
+}
+

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Abstractions;
+using Bit.Core.Abstractions;
 using Bit.Core.Services;
 using System;
 using System.Collections.Generic;
@@ -58,6 +58,7 @@ namespace Bit.Core.Utilities
                 });
             var environmentService = new EnvironmentService(apiService, storageService);
             var cozyClientService = new CozyClientService(tokenService, apiService, environmentService);
+            var cozyClouderyEnvService = new CozyClouderyEnvService(storageService);
             var syncService = new SyncService(userService, apiService, settingsService, folderService,
                 cipherService, cryptoService, collectionService, storageService, messagingService, policyService, sendService, cozyClientService,
                 (bool expired) =>
@@ -96,6 +97,7 @@ namespace Bit.Core.Utilities
             Register<IEnvironmentService>("environmentService", environmentService);
             Register<IEventService>("eventService", eventService);
             Register<ICozyClientService>("cozyClientService", cozyClientService);
+            Register<ICozyClouderyEnvService>("cozyClouderyEnvService", cozyClouderyEnvService);
         }
 
         public static void Register<T>(string serviceName, T obj)


### PR DESCRIPTION
We want to be able to override ClouderyEnv by using an universal link or a scheme link

The app should be able to intercept links containing `cozy_env_override` keyword and extract new ClouderyEnv configuration from it

This feature is needed for debugging purpose so we display a Xamarin alert when a link is intercepted and the configuration is overriden

This feature is based on the same one we implemented on Flagship app project

Related PR: cozy/cozy-flagship-app#654