### PR TITLE
feat: Add universal links support to Android and iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,5 @@ FakesAssemblies/
 project.lock.json
 .DS_Store
 src/App/Css
+
+src/Android/debug.keystore

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -23,6 +23,10 @@ In order to release on iOS:
 ## Debug on Android
 
 In order to debug on Android:
+- Copy the Android's `debug.keystore` from Cozy's password-store into `src/Android/debug.keystore`
+  - Run `pass show cozy-pass/androidOK/debug.keystore > src/Android/debug.keystore`
+  - If you don't have access to Cozy's password-store, just generate a new `debug.keystore` file
+    - Run `keytool -genkey -v -keystore src/Android/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000`
 - Run `Android.csproj` using `CozyDebugAndroid|Any CPU` (or just `CozyReleaseAndroid` on `Visual Studio for Mac`)
 
 ## Release on Android

--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -74,6 +74,13 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CozyDebugIOS|AnyCPU' ">
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CozyDebugAndroid|AnyCPU' ">
+    <AndroidKeyStore>True</AndroidKeyStore>
+    <AndroidSigningKeyStore>./debug.keystore</AndroidSigningKeyStore>
+    <AndroidSigningStorePass>android</AndroidSigningStorePass>
+    <AndroidSigningKeyAlias>androiddebugkey</AndroidSigningKeyAlias>
+    <AndroidSigningKeyPass>android</AndroidSigningKeyPass>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -25,9 +25,16 @@ using Xamarin.Forms.Platform.Android.AppLinks;
 namespace Bit.Droid
 {
     [IntentFilter(
-    new[] { Intent.ActionView },
-    Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
-    DataScheme = "cozypass")]
+        new[] { Intent.ActionView },
+        Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
+        DataScheme = "cozypass")]
+    [IntentFilter(
+        new[] { Intent.ActionView },
+        Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
+        DataScheme = "https",
+        DataHost = "links.mycozy.cloud",
+        DataPathPrefix = "/pass",
+        AutoVerify = true)]
     [Activity(
         Label = "Cozy Pass",
         Icon = "@mipmap/ic_launcher",

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -222,15 +222,17 @@ namespace Bit.App
             var fqdn = queryDictionary.Get("fqdn");
             var onboardingUrl = queryDictionary.Get("onboard_url");
 
-            if ((uri.LocalPath == "/login" || uri.LocalPath == "/onboarding") && !string.IsNullOrEmpty(fqdn))
+            var localPath = uri.LocalPath.StartsWith("/pass") ? uri.LocalPath.Replace("/pass", "") : uri.LocalPath;
+
+            if ((localPath == "/login" || localPath == "/onboarding") && !string.IsNullOrEmpty(fqdn))
             {
                 await HandleLoginLink(fqdn);
             }
-            else if (uri.LocalPath == "/onboarding" && !string.IsNullOrEmpty(onboardingUrl))
+            else if (localPath == "/onboarding" && !string.IsNullOrEmpty(onboardingUrl))
             {
                 await HandleOnboardingLink(onboardingUrl);
             }
-            else if (uri.LocalPath == "/cozy_env_override")
+            else if (localPath == "/cozy_env_override")
             {
                 await CozyEnvironmentOverride.ExtractEnvFromUrl(uri, _cozyClouderyEnvService);
             }

--- a/src/iOS/Entitlements.plist
+++ b/src/iOS/Entitlements.plist
@@ -21,5 +21,9 @@
 		<string>NDEF</string>
 		<string>TAG</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:links.mycozy.cloud</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR configures both Android and iOS projects to support Universal Links (the app only supported `cozypass://` scheme until now)

I also introduced a new debug.keystore file that now should be extracted from our password-store so we can declare its signature in the https://links.mycozy.cloud/.well-known/assetlinks.json file (instructions have been added to `docs/dev.md` file)