### PR TITLE
feat: Change Android TargetSDK for 33 and adapt clipboard management to fit new Android 13 behaviour

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Utilities\ThemeHelpers.cs" />
     <Compile Include="WebAuthCallbackActivity.cs" />
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
+    <Compile Include="Services\ClipboardService.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\FontAwesome.ttf" />

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -62,10 +62,8 @@ namespace Bit.Droid
         private IBroadcasterService _broadcasterService;
         private IUserService _userService;
         private IAppIdService _appIdService;
-        private IStorageService _storageService;
         private IEventService _eventService;
         private ICozyClientService _cozyClientService;
-        private PendingIntent _clearClipboardPendingIntent;
         private PendingIntent _eventUploadPendingIntent;
         private AppOptions _appOptions;
         private string _activityKey = $"{nameof(MainActivity)}_{Java.Lang.JavaSystem.CurrentTimeMillis().ToString()}";
@@ -78,9 +76,6 @@ namespace Bit.Droid
             var eventUploadIntent = new Intent(this, typeof(EventUploadReceiver));
             _eventUploadPendingIntent = PendingIntent.GetBroadcast(this, 0, eventUploadIntent,
                 AndroidHelpers.AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, false));
-            var clearClipboardIntent = new Intent(this, typeof(ClearClipboardAlarmReceiver));
-            _clearClipboardPendingIntent = PendingIntent.GetBroadcast(this, 0, clearClipboardIntent,
-                AndroidHelpers.AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, false));
 
             var policy = new StrictMode.ThreadPolicy.Builder().PermitAll().Build();
             StrictMode.SetThreadPolicy(policy);
@@ -90,7 +85,6 @@ namespace Bit.Droid
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>("broadcasterService");
             _userService = ServiceContainer.Resolve<IUserService>("userService");
             _appIdService = ServiceContainer.Resolve<IAppIdService>("appIdService");
-            _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _eventService = ServiceContainer.Resolve<IEventService>("eventService");
             _cozyClientService = ServiceContainer.Resolve<ICozyClientService>("cozyClientService");
 
@@ -132,10 +126,6 @@ namespace Bit.Droid
                 else if (message.Command == "exit")
                 {
                     ExitApp();
-                }
-                else if (message.Command == "copiedToClipboard")
-                {
-                    var task = ClearClipboardAlarmAsync(message.Data as Tuple<string, int?, bool>);
                 }
             });
         }
@@ -418,30 +408,6 @@ namespace Bit.Droid
         {
             FinishAffinity();
             Java.Lang.JavaSystem.Exit(0);
-        }
-
-        private async Task ClearClipboardAlarmAsync(Tuple<string, int?, bool> data)
-        {
-            if (data.Item3)
-            {
-                return;
-            }
-            var clearMs = data.Item2;
-            if (clearMs == null)
-            {
-                var clearSeconds = await _storageService.GetAsync<int?>(Constants.ClearClipboardKey);
-                if (clearSeconds != null)
-                {
-                    clearMs = clearSeconds.Value * 1000;
-                }
-            }
-            if (clearMs == null)
-            {
-                return;
-            }
-            var triggerMs = Java.Lang.JavaSystem.CurrentTimeMillis() + clearMs.Value;
-            var alarmManager = GetSystemService(AlarmService) as AlarmManager;
-            alarmManager.Set(AlarmType.Rtc, triggerMs, _clearClipboardPendingIntent);
         }
 
         private void StartEventAlarm()

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -12,7 +12,6 @@ using Bit.Core.Abstractions;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.Droid.Services;
-using Bit.Droid.Utilities;
 using Plugin.CurrentActivity;
 using Plugin.Fingerprint;
 using Xamarin.Android.Net;
@@ -94,10 +93,11 @@ namespace Bit.Droid
             var secureStorageService = new SecureStorageService();
             var cryptoPrimitiveService = new CryptoPrimitiveService();
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
-            var deviceActionService = new DeviceActionService(mobileStorageService, messagingService,
+            var clipboardService = new ClipboardService(mobileStorageService);
+            var deviceActionService = new DeviceActionService(clipboardService, mobileStorageService, messagingService,
                 broadcasterService, () => ServiceContainer.Resolve<IEventService>("eventService"));
-            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
-                broadcasterService);
+            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService,
+                messagingService, broadcasterService);
             var biometricService = new BiometricService();
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(mobileStorageService, secureStorageService, cryptoFunctionService);
@@ -110,7 +110,7 @@ namespace Bit.Droid
             ServiceContainer.Register<ICryptoPrimitiveService>("cryptoPrimitiveService", cryptoPrimitiveService);
             ServiceContainer.Register<IStorageService>("storageService", mobileStorageService);
             ServiceContainer.Register<IStorageService>("secureStorageService", secureStorageService);
-            ServiceContainer.Register<IClipboardService>("clipboardService", new ClipboardService(mobileStorageService));
+            ServiceContainer.Register<IClipboardService>("clipboardService", clipboardService);
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);
             ServiceContainer.Register<IBiometricService>("biometricService", biometricService);

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -110,6 +110,7 @@ namespace Bit.Droid
             ServiceContainer.Register<ICryptoPrimitiveService>("cryptoPrimitiveService", cryptoPrimitiveService);
             ServiceContainer.Register<IStorageService>("storageService", mobileStorageService);
             ServiceContainer.Register<IStorageService>("secureStorageService", secureStorageService);
+            ServiceContainer.Register<IClipboardService>("clipboardService", new ClipboardService(mobileStorageService));
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);
             ServiceContainer.Register<IBiometricService>("biometricService", biometricService);

--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -7,7 +7,7 @@
   android:installLocation="internalOnly"
   package="io.cozy.pass">
 
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="32" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.NFC" />

--- a/src/Android/Services/ClipboardService.cs
+++ b/src/Android/Services/ClipboardService.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Bit.Core;
+using Bit.Core.Abstractions;
+using Bit.Droid.Receivers;
+using Plugin.CurrentActivity;
+using Xamarin.Essentials;
+
+namespace Bit.Droid.Services
+{
+    public class ClipboardService : IClipboardService
+    {
+        private readonly IStorageService _storageService;
+        private readonly Lazy<PendingIntent> _clearClipboardPendingIntent;
+
+        public ClipboardService(IStorageService storageService)
+        {
+            _storageService = storageService;
+
+            _clearClipboardPendingIntent = new Lazy<PendingIntent>(() =>
+                PendingIntent.GetBroadcast(CrossCurrentActivity.Current.Activity,
+                                           0,
+                                           new Intent(CrossCurrentActivity.Current.Activity, typeof(ClearClipboardAlarmReceiver)),
+                                           PendingIntentFlags.UpdateCurrent));
+        }
+
+        public async Task CopyTextAsync(string text, int expiresInMs = -1)
+        {
+            await Clipboard.SetTextAsync(text);
+
+            await ClearClipboardAlarmAsync(expiresInMs);
+        }
+
+        private async Task ClearClipboardAlarmAsync(int expiresInMs = -1)
+        {
+            var clearMs = expiresInMs;
+            if (clearMs < 0)
+            {
+                // if not set then we need to check if the user set this config
+                var clearSeconds = await _storageService.GetAsync<int?>(Constants.ClearClipboardKey);
+                if (clearSeconds != null)
+                {
+                    clearMs = clearSeconds.Value * 1000;
+                }
+            }
+            if (clearMs < 0)
+            {
+                return;
+            }
+            var triggerMs = Java.Lang.JavaSystem.CurrentTimeMillis() + clearMs;
+            var alarmManager = CrossCurrentActivity.Current.Activity.GetSystemService(Context.AlarmService) as AlarmManager;
+            alarmManager.Set(AlarmType.Rtc, triggerMs, _clearClipboardPendingIntent.Value);
+        }
+    }
+}

--- a/src/Android/Services/ClipboardService.cs
+++ b/src/Android/Services/ClipboardService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
+using Android.OS;
 using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Droid.Receivers;
@@ -26,11 +27,39 @@ namespace Bit.Droid.Services
                                            PendingIntentFlags.UpdateCurrent));
         }
 
-        public async Task CopyTextAsync(string text, int expiresInMs = -1)
+        public async Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true)
         {
-            await Clipboard.SetTextAsync(text);
+            // Xamarin.Essentials.Clipboard currently doesn't support the IS_SENSITIVE flag for API 33+
+            if ((int)Build.VERSION.SdkInt < 33)
+            {
+                await Clipboard.SetTextAsync(text);
+            }
+            else
+            {
+                CopyToClipboard(text, isSensitive);
+            }
 
             await ClearClipboardAlarmAsync(expiresInMs);
+        }
+
+        public bool IsCopyNotificationHandledByPlatform()
+        {
+            // Android 13+ provides built-in notification when text is copied to the clipboard
+            return (int)Build.VERSION.SdkInt >= 33;
+        }
+
+        private void CopyToClipboard(string text, bool isSensitive = true)
+        {
+            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
+            var clipboardManager = activity.GetSystemService(
+                Context.ClipboardService) as Android.Content.ClipboardManager;
+            var clipData = ClipData.NewPlainText("bitwarden", text);
+            if (isSensitive)
+            {
+                clipData.Description.Extras ??= new PersistableBundle();
+                clipData.Description.Extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
+            }
+            clipboardManager.PrimaryClip = clipData;
         }
 
         private async Task ClearClipboardAlarmAsync(int expiresInMs = -1)

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -33,6 +33,7 @@ namespace Bit.Droid.Services
 {
     public class DeviceActionService : IDeviceActionService
     {
+        private readonly IClipboardService _clipboardService;
         private readonly IStorageService _storageService;
         private readonly IMessagingService _messagingService;
         private readonly IBroadcasterService _broadcasterService;
@@ -43,11 +44,13 @@ namespace Bit.Droid.Services
         private string _userAgent;
 
         public DeviceActionService(
+            IClipboardService clipboardService,
             IStorageService storageService,
             IMessagingService messagingService,
             IBroadcasterService broadcasterService,
             Func<IEventService> eventServiceFunc)
         {
+            _clipboardService = clipboardService;
             _storageService = storageService;
             _messagingService = messagingService;
             _broadcasterService = broadcasterService;
@@ -842,18 +845,10 @@ namespace Bit.Droid.Services
                     var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
                     if (totp != null)
                     {
-                        CopyToClipboard(totp);
+                        await _clipboardService.CopyTextAsync(totp);
                     }
                 }
             }
-        }
-
-        private void CopyToClipboard(string text)
-        {
-            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
-            var clipboardManager = activity.GetSystemService(
-                Context.ClipboardService) as Android.Content.ClipboardManager;
-            clipboardManager.PrimaryClip = ClipData.NewPlainText("bitwarden", text);
         }
     }
 }

--- a/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
@@ -54,8 +54,7 @@ namespace Bit.App.Pages
         private async void CopyAsync(GeneratedPasswordHistory ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            _platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            _platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
         }
     }
 }

--- a/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
@@ -12,6 +12,7 @@ namespace Bit.App.Pages
     {
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly IPasswordGenerationService _passwordGenerationService;
+        private readonly IClipboardService _clipboardService;
 
         private bool _showNoData;
 
@@ -20,6 +21,7 @@ namespace Bit.App.Pages
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _passwordGenerationService = ServiceContainer.Resolve<IPasswordGenerationService>(
                 "passwordGenerationService");
+            _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
 
             PageTitle = AppResources.PasswordHistory;
             History = new ExtendedObservableCollection<GeneratedPasswordHistory>();
@@ -51,7 +53,7 @@ namespace Bit.App.Pages
 
         private async void CopyAsync(GeneratedPasswordHistory ph)
         {
-            await _platformUtilsService.CopyToClipboardAsync(ph.Password);
+            await _clipboardService.CopyTextAsync(ph.Password);
             _platformUtilsService.ShowToast("info", null,
                 string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
         }

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -6,7 +6,6 @@ using Bit.Core.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
@@ -312,8 +311,7 @@ namespace Bit.App.Pages
         public async Task CopyAsync()
         {
             await _clipboardService.CopyTextAsync(Password);
-            _platformUtilsService.ShowToast("success", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            _platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
         }
 
         public bool OptionsToggled

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -14,6 +14,7 @@ namespace Bit.App.Pages
     {
         private readonly IPasswordGenerationService _passwordGenerationService;
         private readonly IPlatformUtilsService _platformUtilsService;
+        private readonly IClipboardService _clipboardService;
 
         private PasswordGenerationOptions _options;
         private PasswordGeneratorPolicyOptions _enforcedPolicyOptions;
@@ -41,6 +42,8 @@ namespace Bit.App.Pages
             _passwordGenerationService = ServiceContainer.Resolve<IPasswordGenerationService>(
                 "passwordGenerationService");
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
+            _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
+
             PageTitle = AppResources.PasswordGenerator;
             TypeOptions = new List<string> { AppResources.Password, AppResources.Passphrase };
         }
@@ -308,7 +311,7 @@ namespace Bit.App.Pages
 
         public async Task CopyAsync()
         {
-            await _platformUtilsService.CopyToClipboardAsync(Password);
+            await _clipboardService.CopyTextAsync(Password);
             _platformUtilsService.ShowToast("success", null,
                 string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
         }

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -29,6 +29,7 @@ namespace Bit.App.Pages
         private readonly IPolicyService _policyService;
         private readonly ICozyClientService _cozyClientService;
         private readonly II18nService _i18nService;
+        private readonly IClipboardService _clipboardService;
 
         private const int CustomVaultTimeoutValue = -100;
 
@@ -77,6 +78,7 @@ namespace Bit.App.Pages
             _policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
             _cozyClientService = ServiceContainer.Resolve<ICozyClientService>("cozyClientService");
             _i18nService = ServiceContainer.Resolve<II18nService>("i18nService");
+            _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
 
             GroupedItems = new ObservableRangeCollection<ISettingsPageListItem>();
             PageTitle = AppResources.Settings;
@@ -130,7 +132,7 @@ namespace Bit.App.Pages
                 AppResources.Close);
             if (copy)
             {
-                await _platformUtilsService.CopyToClipboardAsync(debugText);
+                await _clipboardService.CopyTextAsync(debugText);
             }
         }
 

--- a/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
+++ b/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
@@ -12,6 +12,7 @@ namespace Bit.App.Pages
     {
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly ICipherService _cipherService;
+        private readonly IClipboardService _clipboardService;
 
         private bool _showNoData;
 
@@ -19,6 +20,7 @@ namespace Bit.App.Pages
         {
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _cipherService = ServiceContainer.Resolve<ICipherService>("cipherService");
+            _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
 
             PageTitle = AppResources.PasswordHistory;
             History = new ExtendedObservableCollection<PasswordHistoryView>();
@@ -45,7 +47,7 @@ namespace Bit.App.Pages
 
         private async void CopyAsync(PasswordHistoryView ph)
         {
-            await _platformUtilsService.CopyToClipboardAsync(ph.Password);
+            await _clipboardService.CopyTextAsync(ph.Password);
             _platformUtilsService.ShowToast("info", null,
                 string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
         }

--- a/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
+++ b/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
@@ -48,8 +48,7 @@ namespace Bit.App.Pages
         private async void CopyAsync(PasswordHistoryView ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            _platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            _platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
         }
     }
 }

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -700,7 +700,7 @@ namespace Bit.App.Pages
                 await _clipboardService.CopyTextAsync(text);
                 if (!string.IsNullOrWhiteSpace(name))
                 {
-                    _platformUtilsService.ShowToast("info", null, string.Format(AppResources.ValueHasBeenCopied, name));
+                    _platformUtilsService.ShowToastForCopiedValue(name);
                 }
                 if (id == "LoginPassword")
                 {

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -25,6 +25,8 @@ namespace Bit.App.Pages
         private readonly IMessagingService _messagingService;
         private readonly IEventService _eventService;
         private readonly IPasswordRepromptService _passwordRepromptService;
+        private readonly IClipboardService _clipboardService;
+
         private CipherView _cipher;
         private List<ViewPageFieldViewModel> _fields;
         private bool _canAccessPremium;
@@ -56,6 +58,8 @@ namespace Bit.App.Pages
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _eventService = ServiceContainer.Resolve<IEventService>("eventService");
             _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
+            _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
+
             CopyCommand = new Command<string>((id) => CopyAsync(id, null));
             CopyUriCommand = new Command<LoginUriView>(CopyUri);
             CopyFieldCommand = new Command<FieldView>(CopyField);
@@ -693,7 +697,7 @@ namespace Bit.App.Pages
 
             if (text != null)
             {
-                await _platformUtilsService.CopyToClipboardAsync(text);
+                await _clipboardService.CopyTextAsync(text);
                 if (!string.IsNullOrWhiteSpace(name))
                 {
                     _platformUtilsService.ShowToast("info", null, string.Format(AppResources.ValueHasBeenCopied, name));

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -196,17 +196,6 @@ namespace Bit.App.Services
             return false;
         }
 
-        public async Task CopyToClipboardAsync(string text, Dictionary<string, object> options = null)
-        {
-            var clearMs = options != null && options.ContainsKey("clearMs") ? (int?)options["clearMs"] : null;
-            var clearing = options != null && options.ContainsKey("clearing") ? (bool)options["clearing"] : false;
-            await Clipboard.SetTextAsync(text);
-            if (!clearing)
-            {
-                _messagingService.Send("copiedToClipboard", new Tuple<string, int?, bool>(text, clearMs, clearing));
-            }
-        }
-
         public async Task<string> ReadFromClipboardAsync(Dictionary<string, object> options = null)
         {
             return await Clipboard.GetTextAsync();

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -19,6 +19,7 @@ namespace Bit.App.Services
         private const int DialogPromiseExpiration = 600000; // 10 minutes
 
         private readonly IDeviceActionService _deviceActionService;
+        private readonly IClipboardService _clipboardService;
         private readonly IMessagingService _messagingService;
         private readonly IBroadcasterService _broadcasterService;
         private readonly Dictionary<int, Tuple<TaskCompletionSource<bool>, DateTime>> _showDialogResolves =
@@ -26,10 +27,12 @@ namespace Bit.App.Services
 
         public MobilePlatformUtilsService(
             IDeviceActionService deviceActionService,
+            IClipboardService clipboardService,
             IMessagingService messagingService,
             IBroadcasterService broadcasterService)
         {
             _deviceActionService = deviceActionService;
+            _clipboardService = clipboardService;
             _messagingService = messagingService;
             _broadcasterService = broadcasterService;
         }
@@ -122,6 +125,15 @@ namespace Bit.App.Services
         public bool SupportsDuo()
         {
             return true;
+        }
+
+        public void ShowToastForCopiedValue(string valueNameCopied)
+        {
+            if (!_clipboardService.IsCopyNotificationHandledByPlatform())
+            {
+                ShowToast("info", null,
+                    string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
+            }
         }
 
         public bool SupportsFido2()

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -27,6 +27,8 @@ namespace Bit.App.Utilities
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var eventService = ServiceContainer.Resolve<IEventService>("eventService");
             var vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
+            var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
+
             var options = new List<string> { AppResources.View };
             if (!cipher.IsDeleted)
             {
@@ -92,7 +94,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyUsername)
             {
-                await platformUtilsService.CopyToClipboardAsync(cipher.Login.Username);
+                await clipboardService.CopyTextAsync(cipher.Login.Username);
                 platformUtilsService.ShowToast("info", null,
                     string.Format(AppResources.ValueHasBeenCopied, AppResources.Username));
             }
@@ -100,7 +102,7 @@ namespace Bit.App.Utilities
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
-                    await platformUtilsService.CopyToClipboardAsync(cipher.Login.Password);
+                    await clipboardService.CopyTextAsync(cipher.Login.Password);
                     platformUtilsService.ShowToast("info", null,
                         string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
@@ -114,7 +116,7 @@ namespace Bit.App.Utilities
                     var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
                     if (!string.IsNullOrWhiteSpace(totp))
                     {
-                        await platformUtilsService.CopyToClipboardAsync(totp);
+                        await clipboardService.CopyTextAsync(totp);
                         platformUtilsService.ShowToast("info", null,
                             string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
                     }
@@ -128,7 +130,7 @@ namespace Bit.App.Utilities
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
-                    await platformUtilsService.CopyToClipboardAsync(cipher.Card.Number);
+                    await clipboardService.CopyTextAsync(cipher.Card.Number);
                     platformUtilsService.ShowToast("info", null,
                         string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
                 }
@@ -137,7 +139,7 @@ namespace Bit.App.Utilities
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
-                    await platformUtilsService.CopyToClipboardAsync(cipher.Card.Code);
+                    await clipboardService.CopyTextAsync(cipher.Card.Code);
                     platformUtilsService.ShowToast("info", null,
                         string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
@@ -145,7 +147,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyNotes)
             {
-                await platformUtilsService.CopyToClipboardAsync(cipher.Notes);
+                await clipboardService.CopyTextAsync(cipher.Notes);
                 platformUtilsService.ShowToast("info", null,
                     string.Format(AppResources.ValueHasBeenCopied, AppResources.Notes));
             }
@@ -200,7 +202,8 @@ namespace Bit.App.Utilities
                 return;
             }
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
-            await platformUtilsService.CopyToClipboardAsync(GetSendUrl(send));
+            var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
+            await clipboardService.CopyTextAsync(GetSendUrl(send));
             platformUtilsService.ShowToast("info", null,
                 string.Format(AppResources.ValueHasBeenCopied, AppResources.SendLink));
         }

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -95,16 +95,14 @@ namespace Bit.App.Utilities
             else if (selection == AppResources.CopyUsername)
             {
                 await clipboardService.CopyTextAsync(cipher.Login.Username);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Username));
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Username);
             }
             else if (selection == AppResources.CopyPassword)
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Login.Password);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
                 }
             }
@@ -117,8 +115,7 @@ namespace Bit.App.Utilities
                     if (!string.IsNullOrWhiteSpace(totp))
                     {
                         await clipboardService.CopyTextAsync(totp);
-                        platformUtilsService.ShowToast("info", null,
-                            string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
+                        platformUtilsService.ShowToastForCopiedValue(AppResources.VerificationCodeTotp);
                     }
                 }
             }
@@ -131,8 +128,7 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Number);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.Number);
                 }
             }
             else if (selection == AppResources.CopySecurityCode)
@@ -140,16 +136,14 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Code);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.SecurityCode);
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
                 }
             }
             else if (selection == AppResources.CopyNotes)
             {
                 await clipboardService.CopyTextAsync(cipher.Notes);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Notes));
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Notes);
             }
             return selection;
         }
@@ -204,8 +198,7 @@ namespace Bit.App.Utilities
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
             await clipboardService.CopyTextAsync(GetSendUrl(send));
-            platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.SendLink));
+            platformUtilsService.ShowToastForCopiedValue(AppResources.SendLink);
         }
 
         public static async Task ShareSendUrlAsync(SendView send)

--- a/src/Core/Abstractions/IClipboardService.cs
+++ b/src/Core/Abstractions/IClipboardService.cs
@@ -8,9 +8,17 @@ namespace Bit.Core.Abstractions
         /// Copies the <paramref name="text"/> to the Clipboard.
         /// If <paramref name="expiresInMs"/> is set > 0 then the Clipboard will be cleared after this time in milliseconds.
         /// if less than 0 then it takes the configuration that the user set in Options.
+        /// If <paramref name="isSensitive"/> is true the sensitive flag is passed to the clipdata to obfuscate the
+        /// clipboard text in the popup (Android 13+ only)
         /// </summary>
         /// <param name="text">Text to be copied to the Clipboard</param>
         /// <param name="expiresInMs">Expiration time in milliseconds of the copied text</param>
-        Task CopyTextAsync(string text, int expiresInMs = -1);
+        /// <param name="isSensitive">Flag to mark copied text as sensitive</param>
+        Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true);
+
+        /// <summary>
+        /// Returns true if the platform provides its own notification when text is copied to the clipboard
+        /// </summary>
+        bool IsCopyNotificationHandledByPlatform();
     }
 }

--- a/src/Core/Abstractions/IClipboardService.cs
+++ b/src/Core/Abstractions/IClipboardService.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Bit.Core.Abstractions
+{
+    public interface IClipboardService
+    {
+        /// <summary>
+        /// Copies the <paramref name="text"/> to the Clipboard.
+        /// If <paramref name="expiresInMs"/> is set > 0 then the Clipboard will be cleared after this time in milliseconds.
+        /// if less than 0 then it takes the configuration that the user set in Options.
+        /// </summary>
+        /// <param name="text">Text to be copied to the Clipboard</param>
+        /// <param name="expiresInMs">Expiration time in milliseconds of the copied text</param>
+        Task CopyTextAsync(string text, int expiresInMs = -1);
+    }
+}

--- a/src/Core/Abstractions/IPlatformUtilsService.cs
+++ b/src/Core/Abstractions/IPlatformUtilsService.cs
@@ -23,6 +23,7 @@ namespace Bit.Core.Abstractions
         Task<bool> ShowPasswordDialogAsync(string title, string body, Func<string, Task<bool>> validator);
         void ShowToast(string type, string title, string text, Dictionary<string, object> options = null);
         void ShowToast(string type, string title, string[] text, Dictionary<string, object> options = null);
+        void ShowToastForCopiedValue(string valueNameCopied);
         bool SupportsFido2();
         bool SupportsDuo();
         Task<bool> SupportsBiometricAsync();

--- a/src/Core/Abstractions/IPlatformUtilsService.cs
+++ b/src/Core/Abstractions/IPlatformUtilsService.cs
@@ -9,7 +9,6 @@ namespace Bit.Core.Abstractions
     {
         string IdentityClientId { get; }
 
-        Task CopyToClipboardAsync(string text, Dictionary<string, object> options = null);
         string GetApplicationVersion();
         DeviceType GetDevice();
         string GetDeviceString();

--- a/src/iOS.Core/Services/ClipboardService.cs
+++ b/src/iOS.Core/Services/ClipboardService.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Bit.Core.Abstractions;
+using Foundation;
+using MobileCoreServices;
+using UIKit;
+using Xamarin.Forms;
+
+namespace Bit.iOS.Core.Services
+{
+    public class ClipboardService : IClipboardService
+    {
+        private readonly IStorageService _storageService;
+
+        public ClipboardService(IStorageService storageService)
+        {
+            _storageService = storageService;
+        }
+
+        public async Task CopyTextAsync(string text, int expiresInMs = -1)
+        {
+            int clearSeconds = -1;
+            if (expiresInMs < 0)
+            {
+                clearSeconds = await _storageService.GetAsync<int?>(Bit.Core.Constants.ClearClipboardKey) ?? -1;
+            }
+            else
+            {
+                clearSeconds = expiresInMs * 1000;
+            }
+
+            var dictArr = new NSDictionary<NSString, NSObject>[1];
+            dictArr[0] = new NSDictionary<NSString, NSObject>(new NSString(UTType.UTF8PlainText), new NSString(text));
+            Device.BeginInvokeOnMainThread(() => UIPasteboard.General.SetItems(dictArr, new UIPasteboardOptions
+            {
+                LocalOnly = true,
+                ExpirationDate = clearSeconds > 0 ? NSDate.FromTimeIntervalSinceNow(clearSeconds) : null
+            }));
+        }
+    }
+}

--- a/src/iOS.Core/Services/ClipboardService.cs
+++ b/src/iOS.Core/Services/ClipboardService.cs
@@ -16,8 +16,10 @@ namespace Bit.iOS.Core.Services
             _storageService = storageService;
         }
 
-        public async Task CopyTextAsync(string text, int expiresInMs = -1)
+        public async Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true)
         {
+            // isSensitive is only used by Android for now
+
             int clearSeconds = -1;
             if (expiresInMs < 0)
             {
@@ -35,6 +37,12 @@ namespace Bit.iOS.Core.Services
                 LocalOnly = true,
                 ExpirationDate = clearSeconds > 0 ? NSDate.FromTimeIntervalSinceNow(clearSeconds) : null
             }));
+        }
+
+        public bool IsCopyNotificationHandledByPlatform()
+        {
+            // return true for any future versions of iOS that notify the user when text is copied to the clipboard
+            return false;
         }
     }
 }

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -57,7 +57,7 @@ namespace Bit.iOS.Core.Utilities
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
             var deviceActionService = new DeviceActionService(mobileStorageService, messagingService);
             var clipboardService = new ClipboardService(mobileStorageService);
-            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
+            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService, messagingService,
                 broadcasterService);
             var biometricService = new BiometricService(mobileStorageService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -56,6 +56,7 @@ namespace Bit.iOS.Core.Utilities
             var cryptoPrimitiveService = new CryptoPrimitiveService();
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
             var deviceActionService = new DeviceActionService(mobileStorageService, messagingService);
+            var clipboardService = new ClipboardService(mobileStorageService);
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
                 broadcasterService);
             var biometricService = new BiometricService(mobileStorageService);
@@ -71,6 +72,7 @@ namespace Bit.iOS.Core.Utilities
             ServiceContainer.Register<IStorageService>("storageService", mobileStorageService);
             ServiceContainer.Register<IStorageService>("secureStorageService", secureStorageService);
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
+            ServiceContainer.Register<IClipboardService>("clipboardService", clipboardService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);
             ServiceContainer.Register<IBiometricService>("biometricService", biometricService);
             ServiceContainer.Register<ICryptoFunctionService>("cryptoFunctionService", cryptoFunctionService);

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Views\SwitchTableViewCell.cs" />
     <Compile Include="Views\Toast.cs" />
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
+    <Compile Include="Services\ClipboardService.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -75,14 +75,6 @@ namespace Bit.iOS
                         iOSCoreHelpers.AppearanceAdjustments();
                     });
                 }
-                else if (message.Command == "copiedToClipboard")
-                {
-
-                    Device.BeginInvokeOnMainThread(() =>
-                    {
-                        var task = ClearClipboardTimerAsync(message.Data as Tuple<string, int?, bool>);
-                    });
-                }
                 else if (message.Command == "listenYubiKeyOTP")
                 {
                     iOSCoreHelpers.ListenYubiKey((bool)message.Data, _deviceActionService, _nfcSession, _nfcDelegate);


### PR DESCRIPTION
PlayStore will soon require apps to target SDK 33 (Android 13)

Android 13 now displays copied text in a system popup. This is problematic as the copied text can contain sensitive data
(i.e. passwords), so we want the OS to display the "copied" popup without displaying the clear text

More info:
https://developer.android.com/about/versions/13/features/copy-paste

Related PR: bitwarden/mobile#1947
Related PR: bitwarden/mobile#1679