### PR TITLE
[VO-390] fix: Use universal links on LoginByEmail scenario

### DIFF
--- a/src/Core/Services/CozyClouderyEnvService.cs
+++ b/src/Core/Services/CozyClouderyEnvService.cs
@@ -17,7 +17,7 @@ namespace Bit.Core.Services
 
         private const string LOGIN_RELATIVE_URI = "/v2/neutral/start";
 
-        private const string QUERY_STRING = "redirect_after_email=cozypass%3A%2F%2Fpass%2Fonboarding&redirect_after_login=cozypass%3A%2F%2Fpass%2Flogin";
+        private const string QUERY_STRING = "redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fpass%2Fonboarding%3Ffallback%3Dcozypass%253A%252F%252Fpass%252Fonboarding&redirect_after_login=cozypass%3A%2F%2Fpass%2Flogin";
 
         private readonly IStorageService _storageService;
 


### PR DESCRIPTION
In #86 we reworked the login worflow in order to display the Cloudery web pages instead of a native form. This would allow the user to login by entering their email adresse. The received email would then be opened in a browser which would then redirect to a `cozypass://` scheme

With this scenario, in some environments (i.e. Firefox mobile browser) the user would be redirected to their Cozy login web form instead of being redirect to the Cozy Pass mobile application

This is due to the manager's JS code that would fail opening the `cozypass://` scheme and then redirects to the web login form

In #91 we implemented support to Universal Links, but we did not change the Cloudery url to use them instead of the Scheme

By changing the scheme of an Universal Link, then the login by email scenario would work in more environments like Firefox. This is because the UL redirection is done at HTTP level instead of using a JS script like it was done for Schemes. Also the final fallback is now the `cozypass://` scheme instead of the web login form

This does not fix ALL scenario, in some rare case we can miss some redirection. This is why we changed de Flagship app login to receive an Universal Link directly in the email instead of a manager link (cf cozy/cozy-flagship-app#834)
This may be done in the future, for now this implementation is not prioritized

Related PR: #86
Related PR: #91
Related PR: cozy/cozy-flagship-app#834