### PR TITLE
feat: Remove Profiles concept

### DIFF
--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -105,7 +105,10 @@ namespace Bit.App.Pages
             {
                 new KeyValuePair<string, CipherType>(AppResources.TypeLogin, CipherType.Login),
                 new KeyValuePair<string, CipherType>(AppResources.TypeCard, CipherType.Card),
+                // Cozy Customization, Prevent to create Profiles as they will be replaced by Cozy Contacts
+                /*
                 new KeyValuePair<string, CipherType>(AppResources.TypeIdentity, CipherType.Identity)
+                //*/
             };
             CardBrandOptions = new List<KeyValuePair<string, string>>
             {

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -378,6 +378,15 @@ namespace Bit.App.Pages
             {
                 ToolbarItems.Insert(1, _editItem);
             }
+            // Cozy customization, Prevent to restore/edit/clone/move Profiles as they will be replaced by Cozy Contacts
+            //*
+            if (_vm.Cipher.Type == Core.Enums.CipherType.Identity)
+            {
+                ToolbarItems.Remove(_editItem);
+                ToolbarItems.Remove(_cloneItem);
+                ToolbarItems.Remove(_shareItem);
+            }
+            //*/
         }
     }
 }

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -238,7 +238,7 @@ namespace Bit.App.Pages
             }
         }
         public bool IsDeleted => Cipher.IsDeleted;
-        public bool CanEdit => !Cipher.IsDeleted;
+        public bool CanEdit => !Cipher.IsDeleted && Cipher.Type != CipherType.Identity;
 
         // Cozy customization, display folder (Cozy concept)
         //*

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -30,7 +30,13 @@ namespace Bit.App.Utilities
             var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
 
             var options = new List<string> { AppResources.View };
+
+            // Cozy customization, Prevent to edit Profiles as they will be replaced by Cozy Contacts
+            /*
             if (!cipher.IsDeleted)
+            /*/
+            if (!cipher.IsDeleted && cipher.Type != CipherType.Identity)
+            //*/
             {
                 options.Add(AppResources.Edit);
             }


### PR DESCRIPTION
We want to remove the concept of `Profiles` as they overlap with Cozy's `Contacts`

In cozy-keys-browser we will add the concept of `Contacts` to replace old profiles, but in cozy-pass-mobile we won't add this for now as it would require more work that we did not prioritize yet (we may want to wait for future Bitwarden's announced technology switch)

This PR only prevent from using `Profiles` in the apps, but it does not do any migration process. This will be done on cozy-keys-browser side

Note that contrary to other apps, we don't need to hide the `Profiles` category from the home page because the UI already hides empty categories 

Related PR: cozy/cozy-keys-browser#169
Related PR: cozy/cozy-pass-web#124