### PR TITLE
feat: Remove NFC permission on iOS

### DIFF
--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -278,10 +278,6 @@ namespace Bit.iOS.Core.Services
 
         public bool SupportsNfc()
         {
-            if(Application.Current is App.App currentApp && !currentApp.Options.IosExtension)
-            {
-                return CoreNFC.NFCNdefReaderSession.ReadingAvailable;
-            }
             return false;
         }
 

--- a/src/iOS/Entitlements.plist
+++ b/src/iOS/Entitlements.plist
@@ -16,11 +16,6 @@
 	<array>
 		<string>iCloud.$(CFBundleIdentifier)</string>
 	</array>
-	<key>com.apple.developer.nfc.readersession.formats</key>
-	<array>
-		<string>NDEF</string>
-		<string>TAG</string>
-	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:links.mycozy.cloud</string>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -123,8 +123,6 @@
 	<string>Scan QR codes</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Use Face ID to unlock your vault.</string>
-	<key>NFCReaderUsageDescription</key>
-	<string>Use Yubikeys for two-factor authentication.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>


### PR DESCRIPTION
NFC is used to enable Bitwarden 2FA with Yubikey which we do not use.